### PR TITLE
Add label tool

### DIFF
--- a/aisp-core/aisp-core-main/src/main/java/org/eng/aisp/classifier/anomaly/AnomalyDetectorClassifier.java
+++ b/aisp-core/aisp-core-main/src/main/java/org/eng/aisp/classifier/anomaly/AnomalyDetectorClassifier.java
@@ -175,7 +175,7 @@ public class AnomalyDetectorClassifier extends AbstractFixableFeatureExtractingC
 
 	public static void main(String[] args) throws AISPException {
 		CommandArgs cmdargs = new CommandArgs(args);
-		GetModifiedSoundOptions soundOptions = new GetModifiedSoundOptions(false);
+		GetModifiedSoundOptions soundOptions = new GetModifiedSoundOptions(false, true, false);
 		if (!soundOptions.parseOptions(cmdargs)) {
 			return;
 		}

--- a/aisp-core/aisp-core-main/src/main/java/org/eng/aisp/classifier/anomaly/normal/NormalDistributionAnomalyClassifier.java
+++ b/aisp-core/aisp-core-main/src/main/java/org/eng/aisp/classifier/anomaly/normal/NormalDistributionAnomalyClassifier.java
@@ -127,7 +127,7 @@ public class NormalDistributionAnomalyClassifier extends AnomalyDetectorClassifi
 
 	public static void main(String[] args) throws AISPException {
 			CommandArgs cmdargs = new CommandArgs(args);
-			GetModifiedSoundOptions soundOptions = new GetModifiedSoundOptions(false);
+			GetModifiedSoundOptions soundOptions = new GetModifiedSoundOptions(false, true, false);
 			if (!soundOptions.parseOptions(cmdargs)) {
 				return;
 			}

--- a/aisp-core/aisp-core-main/src/main/java/org/eng/aisp/dataset/ReferencedSoundSpec.java
+++ b/aisp-core/aisp-core-main/src/main/java/org/eng/aisp/dataset/ReferencedSoundSpec.java
@@ -42,37 +42,36 @@ public class ReferencedSoundSpec extends LabeledSegmentSpec implements IReferenc
 
 	/**
 	 * Merge adjacent references that have the same label values and that are adjacent in time.
-	 * Currently it is assumed that references haveing the same reference string will be sequential in the given iterable.
+	 * Currently it is assumed that references having the same reference string will be sequential in the given iterable.
 	 * @param rssList
-	 * @param labelName
 	 * @return
 	 */
-	public static List<ReferencedSoundSpec> mergeLabelValues(Iterable<ReferencedSoundSpec> rssList, String labelName) {
+	public static List<ReferencedSoundSpec> mergeLabelValues(Iterable<ReferencedSoundSpec> rssList) {
 		List<ReferencedSoundSpec> mergedList = new ArrayList<>();
 
-		// First filter out references that don't have the given label.  This makes the subsequent traversal a bit easier.
-		boolean missing = false;
-		for (ReferencedSoundSpec rss : rssList) {
-			String rssLabelValue = rss.getLabels().getProperty(labelName);
-			if (rssLabelValue != null)  {
-				mergedList.add(rss);
-			} else {
-				missing = true;
-			}
-		}
-		if (missing)  {
-			rssList = mergedList;
-			mergedList = new ArrayList<>();
-		} else {
-			mergedList.clear();
-		}
+//		// First filter out references that don't have the given label.  This makes the subsequent traversal a bit easier.
+//		boolean missing = false;
+//		for (ReferencedSoundSpec rss : rssList) {
+//			String rssLabelValue = rss.getLabels().getProperty(labelName);
+//			if (rssLabelValue != null)  {
+//				mergedList.add(rss);
+//			} else {
+//				missing = true;
+//			}
+//		}
+//		if (missing)  {
+//			rssList = mergedList;
+//			mergedList = new ArrayList<>();
+//		} else {
+//			mergedList.clear();
+//		}
 
 		ReferencedSoundSpec lastRSS = null, nextFirstRSS = null;;
 		for (ReferencedSoundSpec rss : rssList) {
 //			AISPLogger.logger.info("rss=" + rss);
 			if (lastRSS != null) {
-				if (nextFirstRSS != null  && !isMergeable(lastRSS, rss, labelName)) {
-					ReferencedSoundSpec mergedRSS = createContinuousReference(nextFirstRSS, lastRSS, labelName); 
+				if (nextFirstRSS != null  && !isMergeable(lastRSS, rss)) {
+					ReferencedSoundSpec mergedRSS = createContinuousReference(nextFirstRSS, lastRSS); 
 					mergedList.add(mergedRSS);
 
 					// Starting a new merged segment.
@@ -85,7 +84,7 @@ public class ReferencedSoundSpec extends LabeledSegmentSpec implements IReferenc
 		}
 		// The last mergable segment still needs to be merged/created.
 		if (nextFirstRSS != lastRSS) {
-			ReferencedSoundSpec mergedRSS = createContinuousReference(nextFirstRSS, lastRSS, labelName); 
+			ReferencedSoundSpec mergedRSS = createContinuousReference(nextFirstRSS, lastRSS); 
 			mergedList.add(mergedRSS);
 		}
 		return mergedList;
@@ -100,18 +99,16 @@ public class ReferencedSoundSpec extends LabeledSegmentSpec implements IReferenc
 	 * NO checking is done to make sure the label values are the same.
 	 * @param firstRSS
 	 * @param lastRSS
-	 * @param labelName
 	 * @return a reference with the star time of the first and end time of the 2nd and with only the given label name and value copied to the new segment.
 	 */
-	private static ReferencedSoundSpec createContinuousReference(ReferencedSoundSpec firstRSS, ReferencedSoundSpec lastRSS,
-			String labelName) {
+	private static ReferencedSoundSpec createContinuousReference(ReferencedSoundSpec firstRSS, ReferencedSoundSpec lastRSS) {
 		String ref = firstRSS.getReference();
-		String labelValue = firstRSS.getLabels().getProperty(labelName);
+//		String labelValue = firstRSS.getLabels().getProperty(labelName);
 		int startMsec= firstRSS.getStartMsec();
 		int endMsec= lastRSS.getEndMsec();
-		Properties labels = new Properties();
-		labels.put(labelName, labelValue);
-		ReferencedSoundSpec mergedRSS = new ReferencedSoundSpec(ref, startMsec, endMsec, labels, null);
+//		Properties labels = new Properties();
+//		labels.put(labelName, labelValue);
+		ReferencedSoundSpec mergedRSS = new ReferencedSoundSpec(ref, startMsec, endMsec, lastRSS.getLabels(), null);
 		return mergedRSS;
 	}
 
@@ -121,17 +118,16 @@ public class ReferencedSoundSpec extends LabeledSegmentSpec implements IReferenc
 	 * Determine if the references and labels match and if the 2nd is adjacent in time following the 1st.
 	 * @param rss1
 	 * @param rss2
-	 * @param labelName
 	 * @return
 	 */
-	private static boolean isMergeable(ReferencedSoundSpec rss1, ReferencedSoundSpec rss2, String labelName) {
+	private static boolean isMergeable(ReferencedSoundSpec rss1, ReferencedSoundSpec rss2) {
 		String ref1 = rss1.getReference();
 		String ref2 = rss2.getReference();
 		if (!ref1.equals(ref2))
 			return false;
-		String l1 = rss1.getLabels().getProperty(labelName);
-		String l2 = rss2.getLabels().getProperty(labelName);
-		if (!l1.equals(l2))
+		Properties l1 = rss1.getLabels();	
+		Properties l2 = rss2.getLabels();
+		if (!l1.equals(l2))	// Compares possibly multiple labels.
 			return false;
 		int end1   = rss1.getEndMsec();
 		int start2 = rss2.getStartMsec();

--- a/aisp-core/aisp-core-main/src/main/java/org/eng/aisp/dataset/ReferencedSoundSpec.java
+++ b/aisp-core/aisp-core-main/src/main/java/org/eng/aisp/dataset/ReferencedSoundSpec.java
@@ -15,9 +15,12 @@
  *******************************************************************************/
 package org.eng.aisp.dataset;
 
+import java.util.ArrayList;
+import java.util.List;
 import java.util.Properties;
 
 import org.eng.aisp.AISPException;
+import org.eng.aisp.AISPLogger;
 import org.eng.aisp.SoundRecording;
 import org.eng.aisp.segmented.LabeledSegmentSpec;
 import org.eng.aisp.segmented.SoundSegmenter;
@@ -36,6 +39,110 @@ public class ReferencedSoundSpec extends LabeledSegmentSpec implements IReferenc
 	protected final String reference;
 	protected transient SoundSegmenter segmenter = null;
 	
+
+	/**
+	 * Merge adjacent references that have the same label values and that are adjacent in time.
+	 * Currently it is assumed that references haveing the same reference string will be sequential in the given iterable.
+	 * @param rssList
+	 * @param labelName
+	 * @return
+	 */
+	public static List<ReferencedSoundSpec> mergeLabelValues(Iterable<ReferencedSoundSpec> rssList, String labelName) {
+		List<ReferencedSoundSpec> mergedList = new ArrayList<>();
+
+		// First filter out references that don't have the given label.  This makes the subsequent traversal a bit easier.
+		boolean missing = false;
+		for (ReferencedSoundSpec rss : rssList) {
+			String rssLabelValue = rss.getLabels().getProperty(labelName);
+			if (rssLabelValue != null)  {
+				mergedList.add(rss);
+			} else {
+				missing = true;
+			}
+		}
+		if (missing)  {
+			rssList = mergedList;
+			mergedList = new ArrayList<>();
+		} else {
+			mergedList.clear();
+		}
+
+		ReferencedSoundSpec lastRSS = null, nextFirstRSS = null;;
+		for (ReferencedSoundSpec rss : rssList) {
+//			AISPLogger.logger.info("rss=" + rss);
+			if (lastRSS != null) {
+				if (nextFirstRSS != null  && !isMergeable(lastRSS, rss, labelName)) {
+					ReferencedSoundSpec mergedRSS = createContinuousReference(nextFirstRSS, lastRSS, labelName); 
+					mergedList.add(mergedRSS);
+
+					// Starting a new merged segment.
+					nextFirstRSS = rss;
+				}
+			} else  {	// First rss in the loop
+				nextFirstRSS = rss;
+			}
+			lastRSS = rss;
+		}
+		// The last mergable segment still needs to be merged/created.
+		if (nextFirstRSS != lastRSS) {
+			ReferencedSoundSpec mergedRSS = createContinuousReference(nextFirstRSS, lastRSS, labelName); 
+			mergedList.add(mergedRSS);
+		}
+		return mergedList;
+	}
+
+
+
+	/**
+	 * Assuming the first and last RSS are the beginning and ending of a continuous mergable set of references, then create
+	 * a single reference that represents that continuous segment.
+	 * <p>
+	 * NO checking is done to make sure the label values are the same.
+	 * @param firstRSS
+	 * @param lastRSS
+	 * @param labelName
+	 * @return a reference with the star time of the first and end time of the 2nd and with only the given label name and value copied to the new segment.
+	 */
+	private static ReferencedSoundSpec createContinuousReference(ReferencedSoundSpec firstRSS, ReferencedSoundSpec lastRSS,
+			String labelName) {
+		String ref = firstRSS.getReference();
+		String labelValue = firstRSS.getLabels().getProperty(labelName);
+		int startMsec= firstRSS.getStartMsec();
+		int endMsec= lastRSS.getEndMsec();
+		Properties labels = new Properties();
+		labels.put(labelName, labelValue);
+		ReferencedSoundSpec mergedRSS = new ReferencedSoundSpec(ref, startMsec, endMsec, labels, null);
+		return mergedRSS;
+	}
+
+
+	
+	/**
+	 * Determine if the references and labels match and if the 2nd is adjacent in time following the 1st.
+	 * @param rss1
+	 * @param rss2
+	 * @param labelName
+	 * @return
+	 */
+	private static boolean isMergeable(ReferencedSoundSpec rss1, ReferencedSoundSpec rss2, String labelName) {
+		String ref1 = rss1.getReference();
+		String ref2 = rss2.getReference();
+		if (!ref1.equals(ref2))
+			return false;
+		String l1 = rss1.getLabels().getProperty(labelName);
+		String l2 = rss2.getLabels().getProperty(labelName);
+		if (!l1.equals(l2))
+			return false;
+		int end1   = rss1.getEndMsec();
+		int start2 = rss2.getStartMsec();
+		if (end1 != start2)
+			return false;
+
+		return true;
+	}
+
+
+
 	public ReferencedSoundSpec(String reference, Properties labels, Properties tags) {
 		this(reference, LabeledSegmentSpec.NON_SEGMENTING_VALUE, LabeledSegmentSpec.NON_SEGMENTING_VALUE, labels,tags);
 	}
@@ -109,8 +216,6 @@ public class ReferencedSoundSpec extends LabeledSegmentSpec implements IReferenc
 		return "ReferencedSoundSpec [reference=" + reference + ", getStartMsec()=" + getStartMsec() + ", getEndMsec()="
 				+ getEndMsec() + ", getLabels()=" + getLabels() + ", getTags()=" + getTags() + "]";
 	}
-
-
 
 
 

--- a/aisp-core/aisp-core-main/src/main/java/org/eng/aisp/tools/Classify.java
+++ b/aisp-core/aisp-core-main/src/main/java/org/eng/aisp/tools/Classify.java
@@ -105,7 +105,7 @@ public class Classify implements ICommandListener {
 			+ "      Start offset, stop offset, label value.  Offsets are in seconds.\n"
 			+ "  -cm : output a confusion matrix.  Sounds must be labeled.\n" 
 			+ "Classify mode options\n"
-			+ GetModifiedSoundOptions.ClipOnlyOptionsHelp
+			+ GetModifiedSoundOptions.ClipLenOnlyOptionsHelp
 			+ "  -t : Show classification time. Times are not effected by console output.\n" 
 			+ "Server mode options:\n"
 			+ "  -server-port port : Specifies the port for the server to run on.  Default is 80.\n" 
@@ -522,7 +522,7 @@ public class Classify implements ICommandListener {
 		PrintStream stdout = System.out;
 		System.setOut(System.err);
 		OnlineStats stats = new OnlineStats();
-		GetModifiedSoundOptions soundOptions = new GetModifiedSoundOptions(false, false);	// No -label, no -balance
+		GetModifiedSoundOptions soundOptions = new GetModifiedSoundOptions(false, false, false);	// No -label, -balance, no -clipShift
 		if (!soundOptions.parseOptions(cmdargs)) 
 			return false;
 		IShuffleIterable<SoundRecording> sounds = soundOptions.getSounds();

--- a/aisp-core/aisp-core-main/src/main/java/org/eng/aisp/tools/CutSounds.java
+++ b/aisp-core/aisp-core-main/src/main/java/org/eng/aisp/tools/CutSounds.java
@@ -31,7 +31,7 @@ public class CutSounds {
 			+ "destination metadata file which is written with the sounds to a destination\n"
 			+ "directory. No files will be overwritten unless the -overwrite option is used.\n"
 			+ "Options:\n"
-			+ GetModifiedSoundOptions.OptionsHelp
+			+ GetModifiedSoundOptions.ClipLenOnlyOptionsHelp
 			+ "  -o <dir>      : sets the directory to store wav files.  This will be created\n"
 			+ "      if it does not already exist. Default is the current directory.\n"
 			+ "  -dest-dir <dir> : same as -o option.\n" 
@@ -69,7 +69,7 @@ public class CutSounds {
 
 	private static boolean doMain(CommandArgs cmdargs, boolean verbose) throws IOException {
 		
-		GetModifiedSoundOptions soundOptions = new GetModifiedSoundOptions(false);
+		GetModifiedSoundOptions soundOptions = new GetModifiedSoundOptions(false, false, false);	// No -label, -balance, or -clipShift
 		if (!soundOptions.parseOptions(cmdargs))
 			return false;		// Error message was issued.
 		Iterable<SoundRecording> sounds = soundOptions.getSounds();

--- a/aisp-core/aisp-core-main/src/main/java/org/eng/aisp/tools/Evaluate.java
+++ b/aisp-core/aisp-core-main/src/main/java/org/eng/aisp/tools/Evaluate.java
@@ -56,9 +56,9 @@ public class Evaluate {
 			+ "  -label (see below)\n" 
 			+ "Options for pre-trained models:\n"
 			+ GetTrainedModelOptions.OptionsHelp
-			+ "  -iterations N: used with the -historize option to define the number of shuffled\n"
-			+ "      iterations over the sounds.  This is helpful to smooth the statistics.\n"
-			+ "      Default is " + DEFAULT_HISTORICAL_ITERATIONS + ".\n" 
+//			+ "  -iterations N: used with the -historize option to define the number of shuffled\n"
+//			+ "      iterations over the sounds.  This is helpful to smooth the statistics.\n"
+//			+ "      Default is " + DEFAULT_HISTORICAL_ITERATIONS + ".\n" 
 
 			+ "Options for model training and K-fold evaluation (-model or -models option) :\n"
 			+ GetModelOptions.OptionsHelp
@@ -84,13 +84,13 @@ public class Evaluate {
 			+ "  -seed <n>  : sets the seed used when shuffling the data prior to fold creation.\n"
 			+ "      The default is a fixed value for repeatability.\n" 
 			+ "Sound specification options:\n"
-			+ GetModifiedSoundOptions.OptionsHelp
+			+ GetModifiedSoundOptions.OptionsWithoutBalanceHelp
 			+ "Additional options for either mode:\n"
 			+ "  -cm : flag requesting that the confusion matrix be printed. Requires the \n"
 			+ "      -label option\n" 
 			+ "  -exportCM <csv file> :  compute and write the confusion matrix to a CSV file.\n"
 			+ "  -serialCM : cause classification to be done serially.  Only needed if a \n" 
-			+ "      classifier is found to not be thread-safe (which is tested for here).\n" 
+			+ "      classifier is found to not be thread-safe.\n" 
 			+ "Examples (local pre-trained model): \n"
 			+ "  ... -file classifier.cfr -sounds mydir\n" 
 			+ "  ... -file classifier.cfr -sounds m1.csv\n" 
@@ -101,11 +101,12 @@ public class Evaluate {
 			+ "  ... -model gmm -sounds mydir -label mylabel\n" 
 			+ "  ... -model jsfile:model.js -sounds m1.csv,m2.csv -label mylabel\n" 
 			+ "  ... -model dcase -sounds mydir1,mydir2 -label mylabel -clipLen 3000 -pad duplicate\n" 
+			+ "  ... -model dcase -sounds mydir1 -label mylabel -clipLen 3000 -clipShift 1500\n" 
 			+ "  ... -model lpnn -sounds mydir -label mylabel -folds 2\n" 
 			+ "  ... -model multilabel -sounds mydir -label mylabel -singleFold -cm\n" 
 			+ "Examples (k-fold evaluation of multiple model): \n"
 			+ "  ... -models models.js -sounds mydir -label mylabel\n" 
-			+ "  ... -models models.js -sounds mydir -label mylabel -folds 3 -balanced\n"
+			+ "  ... -models models.js -sounds mydir -label mylabel -folds 3 -kfoldBalance max\n"
 			+ "  ... -models models.js -sounds mydir -label mylabel -clipLen 4000 -pad duplicate\n"
 			;
 
@@ -178,7 +179,7 @@ public class Evaluate {
 			System.err.println("File " + modelsSpec + " not found");
 			return false;
 		}
-		GetModifiedSoundOptions soundOptions = new GetModifiedSoundOptions(true);
+		GetModifiedSoundOptions soundOptions = new GetModifiedSoundOptions(true, false, true);
 		if (!soundOptions.parseOptions(cmdargs)) 
 			return false;
 
@@ -241,7 +242,7 @@ public class Evaluate {
 		int seed = cmdargs.getOption("seed", KFoldModelEvaluator.DEFAULT_SEED); 
 		boolean parallelCM = !cmdargs.getFlag("serialCM");
 
-		GetModifiedSoundOptions soundOptions = new GetModifiedSoundOptions(true);
+		GetModifiedSoundOptions soundOptions = new GetModifiedSoundOptions(true, false, true);
 		if (!soundOptions.parseOptions(cmdargs)) 
 			return false;
 
@@ -452,21 +453,21 @@ public class Evaluate {
 			throws AISPException, IOException {
 		boolean showCM = cmdargs.getFlag("cm");
 		String exportCM = cmdargs.getOption("exportCM");
-		int iterations = cmdargs.getOption("iterations", DEFAULT_HISTORICAL_ITERATIONS);
+//		int iterations = cmdargs.getOption("iterations", DEFAULT_HISTORICAL_ITERATIONS);
 		boolean parallelCM = !cmdargs.getFlag("-serialCM");
 
 		GetTrainedModelOptions modelOptions = new GetTrainedModelOptions();
 		if (!modelOptions.parseOptions(cmdargs)) 
 			return false;				// Error message was issued
 		
-		GetModifiedSoundOptions soundOptions = new GetModifiedSoundOptions(false);	// If label not given, use the model's label
+		GetModifiedSoundOptions soundOptions = new GetModifiedSoundOptions(false,true,true);	// If label not given, use the model's label
 		if (!soundOptions.parseOptions(cmdargs)) 
 			return false;
 
-		if (iterations < 1) {
-			System.err.println("Number of iterations must be 1 or larger.");
-			return false;
-		}
+//		if (iterations < 1) {
+//			System.err.println("Number of iterations must be 1 or larger.");
+//			return false;
+//		}
 		
 		// Done parsing options, make sure there are none we don't recognize.
 		if (ToolUtils.hasUnusedArguments(cmdargs))

--- a/aisp-core/aisp-core-main/src/main/java/org/eng/aisp/tools/GetModifiedSoundOptions.java
+++ b/aisp-core/aisp-core-main/src/main/java/org/eng/aisp/tools/GetModifiedSoundOptions.java
@@ -118,7 +118,7 @@ public class GetModifiedSoundOptions extends GetSoundOptions {
 		this.clipLenMsec = cmdargs.getOption("clipLen", DEFAULT_CLIPLEN); 
 
 		PadType padType; 
-		boolean repeatableShuffle = !cmdargs.getFlag("no-repeatabilitye"); 
+		boolean repeatableShuffle = !cmdargs.getFlag("no-repeatability"); 
 		
 		// Padding option
 		String padOption = cmdargs.getOption("pad", "no");

--- a/aisp-core/aisp-core-main/src/main/java/org/eng/aisp/tools/GetModifiedSoundOptions.java
+++ b/aisp-core/aisp-core-main/src/main/java/org/eng/aisp/tools/GetModifiedSoundOptions.java
@@ -35,7 +35,7 @@ public class GetModifiedSoundOptions extends GetSoundOptions {
 
 	private final static String ClipLenOptionsHelp = 
              // xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
-			  "  -clipLen double : splits sound recordings up into clips of the given\n"
+			  "  -clipLen int: splits sound recordings up into clips of the given\n"
 			+ "      number of milliseconds. Set to 0 to turn off.\n"
 			+ "      Defaults to " + DEFAULT_CLIPLEN + ".\n" 
 			+ "  -pad (no|zero|duplicate): when clips are shorter than the requests clip\n"
@@ -48,7 +48,7 @@ public class GetModifiedSoundOptions extends GetSoundOptions {
 
 	private final static String ClipShiftOptionsHelp = 
             // xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
-			  "  -clipShift double : defines the time difference between the start times of\n" 
+			  "  -clipShift int : defines the time difference between the start times of\n" 
 			+ "      the sub-windows in milliseconds. Not used unless -clipLen option is set.\n"
 			+ "      Set to 0 or the clipLen value to define rolling windows. Set to half the\n"
 			+ "      clipLen to define sub-windows in which the last half of a window overlaps\n"
@@ -230,11 +230,18 @@ public class GetModifiedSoundOptions extends GetSoundOptions {
 	 * @param useUpSampling
 	 * @return
 	 */
+    // xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
+	// Sounds will be clipped every 50 msec into 100.0 msec clips (padding=NoPad)
 	private IShuffleIterable<SoundRecording> getRequestedSounds(IShuffleIterable<SoundRecording> sounds,
-			String trainingLabel, boolean repeatableShuffle, double clipLenMsec, int clipShiftMsec, PadType padType,
+			String trainingLabel, boolean repeatableShuffle, int clipLenMsec, int clipShiftMsec, PadType padType,
 			boolean balancedLabels, int balancedCount, boolean useUpSampling) {
 		if (clipLenMsec > 0) { 
-			System.out.println("Sounds will be clipped into " + clipLenMsec + " millisecond clips (padding=" + padType.name() + ").");
+			String msg;
+			if (clipShiftMsec != 0)
+				msg = "Sounds will be clipped every " + clipShiftMsec + " msec into " + clipLenMsec + " msec clips (padding=" + padType.name() + ")";
+			else
+				msg = "Sounds will be clipped every " + clipLenMsec + " msec into " + clipLenMsec + " msec clips (padding=" + padType.name() + ")";
+			System.out.println(msg);
 			sounds = new FixedDurationSoundRecordingShuffleIterable(sounds, clipLenMsec, clipShiftMsec, padType);
 //			System.out.println(TrainingSetInfo.getInfo(sounds).prettyFormat());
 //			if (repeatableShuffle && balancedLabels) {

--- a/aisp-core/aisp-core-main/src/main/java/org/eng/aisp/tools/Label.java
+++ b/aisp-core/aisp-core-main/src/main/java/org/eng/aisp/tools/Label.java
@@ -47,7 +47,7 @@ public class Label {
 			  "Classifies sounds using a model to produce a metadata-formatted labeling of the\n"
 			+ "sounds on stdou.  While the -clipLen option is not strictly required, it is \n"
 			+ "typically used to classify sub-segments of the input sound(s).  Segments from\n"
-			+ "the same file that are are adjacent in time and have the same label name as \n" 
+			+ "the same file that are adjacent in time and have the same label name as \n" 
 			+ "produced by the model will be merged.\n"
 			+ "Classify mode options\n"
 			+ GetModifiedSoundOptions.ClipOnlyOptionsHelp

--- a/aisp-core/aisp-core-main/src/main/java/org/eng/aisp/tools/Label.java
+++ b/aisp-core/aisp-core-main/src/main/java/org/eng/aisp/tools/Label.java
@@ -41,7 +41,7 @@ public class Label {
 	public final static String Usage = 
              //xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
 			  "Classifies sounds using a model to produce a metadata-formatted labeling of the\n"
-			+ "sounds on stdou.  While the -clipLen option is not strictly required, it is \n"
+			+ "sounds on stdout.  While the -clipLen option is not strictly required, it is \n"
 			+ "typically used to classify sub-segments of the input sound(s).  Segments from\n"
 			+ "the same file that are adjacent in time and have the same label name as \n" 
 			+ "produced by the model will be merged.\n"

--- a/aisp-core/aisp-core-main/src/main/java/org/eng/aisp/tools/Label.java
+++ b/aisp-core/aisp-core-main/src/main/java/org/eng/aisp/tools/Label.java
@@ -1,0 +1,173 @@
+/*******************************************************************************
+ * Copyright [2022] [IBM]
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *******************************************************************************/
+package org.eng.aisp.tools;
+
+import java.io.IOException;
+import java.io.PrintStream;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Properties;
+
+import com.google.gson.Gson;
+
+import org.eng.aisp.AISPException;
+import org.eng.aisp.AISPRuntime;
+import org.eng.aisp.SoundClip;
+import org.eng.aisp.SoundRecording;
+import org.eng.aisp.classifier.Classification;
+import org.eng.aisp.classifier.IFixedClassifier;
+import org.eng.aisp.client.IAsyncSensorClient.ICommandListener;
+import org.eng.aisp.dataset.IReferencedSoundSpec;
+import org.eng.aisp.dataset.MetaData;
+import org.eng.aisp.dataset.ReferencedSoundSpec;
+import org.eng.util.CommandArgs;
+import org.eng.util.OnlineStats;
+
+public class Label {
+
+
+	public final static String Usage = 
+             //xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
+			  "Classifies sounds using a model to produce a metadata-formatted labeling of the\n"
+			+ "sounds on stdou.  While the -clipLen option is not strictly required, it is \n"
+			+ "typically used to classify sub-segments of the input sound(s).  Segments from\n"
+			+ "the same file that are are adjacent in time and have the same label name as \n" 
+			+ "produced by the model will be merged.\n"
+			+ "Classify mode options\n"
+			+ GetModifiedSoundOptions.ClipOnlyOptionsHelp
+			+ "Label examples: \n"
+			+ "  ... -file myclassifier.cfr -clipLen 1000 number1.wav number2.wav\n"
+			+ "  ... -file myclassifier.cfr -clipLen 1000 -pad duplicate number1.wav\n"
+			+ "  ... -file myclassifier.cfr -clipLen 1000 -pad duplicate -sounds metadata.csv\n"
+			;
+
+	public static void main(String args[]) {
+		// Try to redirect initial output to stderr, so users can redirectory classification output into a file.
+		PrintStream stdout = System.out;
+		System.setOut(System.err);
+
+		// Force any framework initialization messages to come out first.
+		AISPRuntime.getRuntime();
+		System.out.println("\n");	// blank line to separate copyrites, etc.
+		
+		CommandArgs cmdargs = new CommandArgs(args);
+
+		// Check for help request
+		if (cmdargs.getFlag("h") || cmdargs.getFlag("-help") ) {
+			System.out.println(Usage);
+			return;
+	    }
+		System.setOut(stdout);
+
+		Label c = new Label();
+		try {
+			if (!c.doMain(cmdargs))
+				System.err.println("Use -help option to see usage");
+		} catch (Exception e) {
+			System.err.println("ERROR: " + e.getMessage());
+			if (cmdargs.getFlag("v"))
+				e.printStackTrace();
+		}
+		
+	}
+	
+
+	/**
+	 * Do the work implied by the arguments.
+	 * @param cmdargs
+	 * @return false and issue an error message on error, otherwise true.
+	 * @throws AISPException
+	 * @throws IOException 
+	 */
+	protected boolean doMain(CommandArgs cmdargs) throws AISPException, IOException {
+	
+		// Point stdout at stderr so that messages produced during argument parsing do not appear in 
+		// redirected command lines (ala classify > file.out).
+		PrintStream stdout = System.out;
+		System.setOut(System.err);
+		
+		// Load the named classifier or setup for remote classification
+		GetTrainedModelOptions modelOptions = new GetTrainedModelOptions();
+		if (!modelOptions.parseOptions(cmdargs)) 
+			return false;
+		IFixedClassifier<double[]> classifier = modelOptions.getClassifier();
+		if (classifier == null)
+			return false;
+		
+		OnlineStats stats = new OnlineStats();
+		GetModifiedSoundOptions soundOptions = new GetModifiedSoundOptions(false, false);	// No -label, no -balance
+		if (!soundOptions.parseOptions(cmdargs)) 
+			return false;
+		Iterable<SoundRecording> sounds = soundOptions.getSounds();
+		System.setOut(stdout);	
+		
+		labelSounds(classifier, sounds);
+
+		return true;
+
+	}
+
+
+	private void labelSounds(IFixedClassifier<double[]> classifier, Iterable<SoundRecording> sounds) throws AISPException, IOException {
+
+		// See if there are duplicate filenames so that we know whether or not to include indices and start/stop times.
+		Map<String, List<ReferencedSoundSpec>> labelings = new HashMap<>();
+		String trainedLabel = classifier.getTrainedLabel();
+		for (SoundRecording sr : sounds) {
+			Properties tags = sr.getTagsAsProperties();
+			String fileName = tags.getProperty(MetaData.FILENAME_TAG);
+			
+			// Classify the sample and keep track of the amount of time. 
+			SoundClip clip = sr.getDataWindow(); 
+			Map<String,Classification> classifications = classifier.classify(clip);
+			Classification c = classifications.get(trainedLabel);
+			if (c == null) {
+				System.err.println("Model did not produce a classification with label " + trainedLabel);
+				continue;
+			}
+			int startMsec = (int)Math.round(clip.getStartTimeMsec()); 
+			int endMsec = (int)Math.round(clip.getEndTimeMsec()); 
+			Properties labels = new Properties();
+			labels.put(trainedLabel, c.getLabelValue());
+			ReferencedSoundSpec rss = new ReferencedSoundSpec(fileName, startMsec, endMsec, labels,null);
+			List<ReferencedSoundSpec> rssList = labelings.get(fileName);
+			if (rssList == null) {
+				rssList = new ArrayList<>();
+				labelings.put(fileName, rssList);
+			}
+			rssList.add(rss);
+		}
+		
+		List<String> fileNames = new ArrayList<>();
+		fileNames.addAll(labelings.keySet());
+		Collections.sort(fileNames);
+		
+		MetaData md = new MetaData();
+		for (String fn : fileNames) {
+			List<ReferencedSoundSpec> rssList = labelings.get(fn);
+			rssList = ReferencedSoundSpec.mergeLabelValues(rssList, trainedLabel);
+			for (ReferencedSoundSpec rss : rssList) 
+				md.add(rss);
+		}
+		md.write(System.out, true, false);
+
+	}
+
+
+}

--- a/aisp-core/aisp-core-main/src/main/java/org/eng/aisp/tools/Label.java
+++ b/aisp-core/aisp-core-main/src/main/java/org/eng/aisp/tools/Label.java
@@ -50,7 +50,7 @@ public class Label {
 			+ "the same file that are adjacent in time and have the same label name as \n" 
 			+ "produced by the model will be merged.\n"
 			+ "Classify mode options\n"
-			+ GetModifiedSoundOptions.ClipOnlyOptionsHelp
+			+ GetModifiedSoundOptions.ClipLenOnlyOptionsHelp
 			+ "Label examples: \n"
 			+ "  ... -file myclassifier.cfr -clipLen 1000 number1.wav number2.wav\n"
 			+ "  ... -file myclassifier.cfr -clipLen 1000 -pad duplicate number1.wav\n"
@@ -111,7 +111,7 @@ public class Label {
 			return false;
 		
 		OnlineStats stats = new OnlineStats();
-		GetModifiedSoundOptions soundOptions = new GetModifiedSoundOptions(false, false);	// No -label, no -balance
+		GetModifiedSoundOptions soundOptions = new GetModifiedSoundOptions(false, false,false);	// No -label, no -balance, no -clipShift
 		if (!soundOptions.parseOptions(cmdargs)) 
 			return false;
 		Iterable<SoundRecording> sounds = soundOptions.getSounds();

--- a/aisp-core/aisp-core-main/src/main/java/org/eng/aisp/tools/Label.java
+++ b/aisp-core/aisp-core-main/src/main/java/org/eng/aisp/tools/Label.java
@@ -24,16 +24,12 @@ import java.util.List;
 import java.util.Map;
 import java.util.Properties;
 
-import com.google.gson.Gson;
-
 import org.eng.aisp.AISPException;
 import org.eng.aisp.AISPRuntime;
 import org.eng.aisp.SoundClip;
 import org.eng.aisp.SoundRecording;
 import org.eng.aisp.classifier.Classification;
 import org.eng.aisp.classifier.IFixedClassifier;
-import org.eng.aisp.client.IAsyncSensorClient.ICommandListener;
-import org.eng.aisp.dataset.IReferencedSoundSpec;
 import org.eng.aisp.dataset.MetaData;
 import org.eng.aisp.dataset.ReferencedSoundSpec;
 import org.eng.util.CommandArgs;
@@ -49,7 +45,7 @@ public class Label {
 			+ "typically used to classify sub-segments of the input sound(s).  Segments from\n"
 			+ "the same file that are adjacent in time and have the same label name as \n" 
 			+ "produced by the model will be merged.\n"
-			+ "Classify mode options\n"
+			+ GetTrainedModelOptions.OptionsHelp
 			+ GetModifiedSoundOptions.ClipLenOnlyOptionsHelp
 			+ "Label examples: \n"
 			+ "  ... -file myclassifier.cfr -clipLen 1000 number1.wav number2.wav\n"

--- a/aisp-core/aisp-core-main/src/main/java/org/eng/aisp/tools/SoundInfo.java
+++ b/aisp-core/aisp-core-main/src/main/java/org/eng/aisp/tools/SoundInfo.java
@@ -69,7 +69,7 @@ public class SoundInfo {
 	protected static boolean doMain(CommandArgs cmdargs) throws AISPException, IOException {
 	
 		Iterable<SoundRecording> sounds; 
-		GetModifiedSoundOptions soundOptions = new GetModifiedSoundOptions(false);
+		GetModifiedSoundOptions soundOptions = new GetModifiedSoundOptions(false, true, true);
 		if (soundOptions.hasApplicableOptions(cmdargs)) {
 			if (!soundOptions.parseOptions(cmdargs))
 				return false;

--- a/aisp-core/aisp-core-main/src/main/java/org/eng/aisp/tools/Train.java
+++ b/aisp-core/aisp-core-main/src/main/java/org/eng/aisp/tools/Train.java
@@ -116,7 +116,7 @@ public class Train {
 		IClassifier<double[]> classifier =  modelOptions.getClassifier(); 
 		
 		// Parse the options the specify the sounds to be used.
-		GetModifiedSoundOptions soundOptions = new GetModifiedSoundOptions(true);
+		GetModifiedSoundOptions soundOptions = new GetModifiedSoundOptions(true, true, true);
 		if (!soundOptions.parseOptions(cmdargs))
 			return false;
 		String trainingLabel = soundOptions.getLabel();

--- a/aisp-core/aisp-core-main/src/main/java/org/eng/aisp/tools/Train.java
+++ b/aisp-core/aisp-core-main/src/main/java/org/eng/aisp/tools/Train.java
@@ -54,7 +54,7 @@ public class Train {
 			+ "Additional options:\n"
 			+ "  -noinfo : causes no information about the training data to be displayed.\n"
 			+ "      This may be useful to speed training on large training sets.\n"
-			+ "  -output <file> : a file into which the classifier can be written. Optional.\n" 
+			+ "  -file <file> : a file into which the classifier can be written. Optional.\n" 
 			+ "  -data-type (audio|xyz|mag) : specifies the type of data contained in the wav\n"
 			+ "      files and attaches an associated data type tag to the trained model.\n"
 			+ "      Default is audio.\n"
@@ -64,9 +64,9 @@ public class Train {
 
 			+ "Examples: \n"
 			+ "  ... -label status -sounds m1.csv,m2.csv-output classifier.cfr \n" 
-			+ "  ... -label status -sounds m3.csv -output classifier.cfr -model jsfile:model.js\n" 
-			+ "  ... -label status -sounds mydir -output classifier.cfr -model gmm\n" 
-			+ "  ... -label status -sounds mydir -output classifier.cfr -model gmm -data-type xyz\n" 
+			+ "  ... -label status -sounds m3.csv -file classifier.cfr -model model.js\n" 
+			+ "  ... -label status -sounds mydir -file classifier.cfr -model gmm\n" 
+			+ "  ... -label status -sounds mydir -file classifier.cfr -model gmm -data-type xyz\n" 
 			;
 
 	public static void main(String args[]) {
@@ -98,7 +98,9 @@ public class Train {
 	protected static boolean doMain(CommandArgs cmdargs, boolean verbose) throws AISPException, IOException {
 		
 		// Get the name of the model to use.
-		String outputFileName = cmdargs.getOption("output");
+		String outputFileName = cmdargs.getOption("file");	// Use the same option as CLIs that load models from the file system.
+		if (outputFileName == null)
+			outputFileName = cmdargs.getOption("output");	// For backwards compatability (used to be -output).
 		boolean noinfo = cmdargs.getFlag("noinfo");
 		boolean storeFixed = cmdargs.getFlag("fixed");
 		DataTypeEnum dataType = DataTypeEnum.Audio;

--- a/aisp-core/aisp-core-main/src/main/java/org/eng/aisp/util/AbstractSegmentingMutator.java
+++ b/aisp-core/aisp-core-main/src/main/java/org/eng/aisp/util/AbstractSegmentingMutator.java
@@ -18,6 +18,7 @@ package org.eng.aisp.util;
 import java.util.ArrayList;
 import java.util.List;
 
+import org.eng.aisp.AISPLogger;
 import org.eng.aisp.IDataWindow;
 import org.eng.aisp.IDataWindow.PadType;
 import org.eng.aisp.ILabeledDataWindow;
@@ -78,7 +79,7 @@ public abstract class AbstractSegmentingMutator<LDW extends ILabeledDataWindow<d
 	private List<IDataWindow<double[]>> getSlidingSubWindows(IDataWindow<double[]> window) {
 		List<IDataWindow<double[]>> subList = new ArrayList<>();
 		double startMsec = 0;
-		double nextEndMsec = this.windowShiftMsec; 
+		double nextEndMsec = this.windowSizeMsec; 
 		double durationMsec = window.getDurationMsec();
 		boolean keepTrailingWindow = padType != PadType.NoPad;
 		while (nextEndMsec <= durationMsec)  {
@@ -88,6 +89,8 @@ public abstract class AbstractSegmentingMutator<LDW extends ILabeledDataWindow<d
 			subList.add(sub);
 			startMsec += this.windowShiftMsec;
 			nextEndMsec += this.windowShiftMsec;
+			AISPLogger.logger.info("sub start=" + sub.getStartTimeMsec() + " end="+sub.getEndTimeMsec() 
+			+ ",star/end=" + startMsec + "/" + nextEndMsec); 
 		}
 		
 		if (keepTrailingWindow && startMsec < durationMsec) {

--- a/aisp-core/aisp-core-main/src/main/java/org/eng/aisp/util/AbstractSegmentingMutator.java
+++ b/aisp-core/aisp-core-main/src/main/java/org/eng/aisp/util/AbstractSegmentingMutator.java
@@ -89,8 +89,8 @@ public abstract class AbstractSegmentingMutator<LDW extends ILabeledDataWindow<d
 			subList.add(sub);
 			startMsec += this.windowShiftMsec;
 			nextEndMsec += this.windowShiftMsec;
-			AISPLogger.logger.info("sub start=" + sub.getStartTimeMsec() + " end="+sub.getEndTimeMsec() 
-			+ ",star/end=" + startMsec + "/" + nextEndMsec); 
+//			AISPLogger.logger.info("sub start=" + sub.getStartTimeMsec() + " end="+sub.getEndTimeMsec() 
+//			+ ",star/end=" + startMsec + "/" + nextEndMsec); 
 		}
 		
 		if (keepTrailingWindow && startMsec < durationMsec) {

--- a/aisp-core/aisp-core-main/src/main/java/org/eng/aisp/util/BalancedLabeledWindowShuffleIterable.java
+++ b/aisp-core/aisp-core-main/src/main/java/org/eng/aisp/util/BalancedLabeledWindowShuffleIterable.java
@@ -62,13 +62,13 @@ public class BalancedLabeledWindowShuffleIterable<ITEM extends ILabeledDataWindo
 			List<Integer> itemHashcodes = new ArrayList<>();
 			Map<String,Integer> labelCounts = new HashMap<>();
 			
-//			AISPLogger.logger.info("Enter: " + TrainingSetInfo.getInfo(iterable).prettyFormat());
+			AISPLogger.logger.info("Enter: " + TrainingSetInfo.getInfo(iterable).prettyFormat());
 			for (ITEM item : iterable) {
 				String labelValue = item.getLabels().getProperty(labelName);
-				int hashCode = item.hashCode();
-				itemLabelValues.add(labelValue);
-				itemHashcodes.add(hashCode);
 				if (labelValue != null) {
+					int hashCode = item.hashCode();
+					itemLabelValues.add(labelValue);
+					itemHashcodes.add(hashCode);
 					Integer count = labelCounts.get(labelValue);
 					int icount;
 					if (count == null)
@@ -110,6 +110,8 @@ public class BalancedLabeledWindowShuffleIterable<ITEM extends ILabeledDataWindo
 				// Loop until we've accumulated enough items having this label value.
 				while (allocated < samplesPerLabelValue) {
 					String thisItemLabel = itemLabelValues.get(index);
+					if (thisItemLabel == null)
+						index = index;
 					if (thisItemLabel.equals(labelValue)) {
 						// This is an item with the label, so add an instance of it to the items for this label.
 						int count = itemCounts.get(index) + 1;

--- a/aisp-core/aisp-core-main/src/main/java/org/eng/aisp/util/FixedDurationSoundRecordingIterable.java
+++ b/aisp-core/aisp-core-main/src/main/java/org/eng/aisp/util/FixedDurationSoundRecordingIterable.java
@@ -29,10 +29,17 @@ public class FixedDurationSoundRecordingIterable extends MutatingIterable<SoundR
 	/**
 	 * Create the iterable to take sub windows of the given size from the SoundRecordings in the given iterable. 
 	 * @param sounds iterable over SoundRecordings for which subwindows are desired.
-	 * @param subWindowMsec the size of all subwindows extracted from the SoundRecordings in the given iterable.
+	 * @param windowSizeMsec the size of all subwindows extracted from the SoundRecordings in the given iterable.
+	 * @param windowShiftMsec the difference in time between the start of adjacent sub windows.  Set to 0 or windowSizeMsec to get rolling windows.
+	 * Set to some other value (generally smaller then windowSizeMsec) to get sliding windows.
+	 * @param padType
 	 */
-	public FixedDurationSoundRecordingIterable(Iterable<SoundRecording> sounds, double subWindowMsec, IDataWindow.PadType padType) {
-		super(sounds, new SoundRecordingSegmentingMutator(subWindowMsec, padType));
+	public FixedDurationSoundRecordingIterable(Iterable<SoundRecording> sounds, double windowSizeMsec, double windowShiftMsec, IDataWindow.PadType padType) {
+		super(sounds, new SoundRecordingSegmentingMutator(windowSizeMsec, windowShiftMsec, padType));
+	}
+
+	public FixedDurationSoundRecordingIterable(Iterable<SoundRecording> sounds, double windowSizeMsec, IDataWindow.PadType padType) {
+		this(sounds, windowSizeMsec, 0, padType); 
 	}
 
 }

--- a/aisp-core/aisp-core-main/src/main/java/org/eng/aisp/util/FixedDurationSoundRecordingShuffleIterable.java
+++ b/aisp-core/aisp-core-main/src/main/java/org/eng/aisp/util/FixedDurationSoundRecordingShuffleIterable.java
@@ -49,7 +49,18 @@ public class FixedDurationSoundRecordingShuffleIterable extends MutatingShuffleI
 	 * @param windowMsec the size of all subwindows extracted from the SoundRecordings in the given iterable.
 	 */
 	public FixedDurationSoundRecordingShuffleIterable(IShuffleIterable<SoundRecording> sounds, double windowMsec, IDataWindow.PadType padType) {
-		super(sounds, new Segmenter(new SoundRecordingSegmentingMutator(windowMsec, padType)));
+		this(sounds, windowMsec, 0, padType); 
+	}
+
+	/**
+	 * 
+	 * @param sounds iterable over SoundRecordings for which subwindows are desired.
+	 * @param windowSizeMsec the size of all subwindows extracted from the SoundRecordings in the given iterable.
+	 * @param windowShiftMsec the time between each sub-window.  Set to 0 or windowSizeMsec value to get rolling windows.  
+	 * @param padType
+	 */
+	public FixedDurationSoundRecordingShuffleIterable(IShuffleIterable<SoundRecording> sounds, double windowSizeMsec, double windowShiftMsec, IDataWindow.PadType padType) {
+		super(sounds, new Segmenter(new SoundRecordingSegmentingMutator(windowSizeMsec, windowShiftMsec, padType)));
 	}
 
 

--- a/aisp-core/aisp-core-main/src/main/java/org/eng/aisp/util/SoundRecordingSegmentingMutator.java
+++ b/aisp-core/aisp-core-main/src/main/java/org/eng/aisp/util/SoundRecordingSegmentingMutator.java
@@ -22,8 +22,12 @@ import org.eng.aisp.SoundRecording;
 
 public class SoundRecordingSegmentingMutator extends AbstractSegmentingMutator<SoundRecording> {
 
-	public SoundRecordingSegmentingMutator(double windowMsec, PadType padType) {
-		super(windowMsec, padType);
+	public SoundRecordingSegmentingMutator(double windowSizeMsec, PadType padType) {
+		super(windowSizeMsec, 0, padType);
+	}
+
+	public SoundRecordingSegmentingMutator(double windowSizeMsec, double windowShiftMsec, PadType padType) {
+		super(windowSizeMsec, windowShiftMsec, padType);
 	}
 
 	@Override

--- a/aisp-core/aisp-core-main/src/main/java/org/eng/util/IterableIterable.java
+++ b/aisp-core/aisp-core-main/src/main/java/org/eng/util/IterableIterable.java
@@ -27,7 +27,7 @@ import java.util.NoSuchElementException;
  */
 public class IterableIterable<T> implements Iterable<T> {
 
-	protected final Iterable<Iterable<T>> iterables;
+	protected final Iterable<? extends Iterable<T>> iterables;
 	
 	/**
 	 * The Iterator created by the IterableIterable class.
@@ -38,9 +38,9 @@ public class IterableIterable<T> implements Iterable<T> {
 	private static class IteratableIterator<T> implements Iterator<T> {
 
 		protected Iterator<T> currentIterator = null;
-		protected final Iterator<Iterable<T>> iterables;
+		protected final Iterator<? extends Iterable<T>> iterables;
 
-		public IteratableIterator(Iterator<Iterable<T>> iterables) {
+		public IteratableIterator(Iterator<? extends Iterable<T>> iterables) {
 			this.iterables = iterables;
 			if (iterables.hasNext())
 				currentIterator = iterables.next().iterator();
@@ -80,7 +80,7 @@ public class IterableIterable<T> implements Iterable<T> {
 	 * Create the instance to create an Iterator that iterates of each of the items in the iterables as if they were in a single Iterable.
 	 * @param iterables
 	 */
-	public IterableIterable(Iterable<Iterable<T>> iterables) {
+	public IterableIterable(Iterable<? extends Iterable<T>> iterables) {
 		this.iterables = iterables;
 	}
 

--- a/aisp-core/aisp-core-main/src/main/scripts/enable-gpu
+++ b/aisp-core/aisp-core-main/src/main/scripts/enable-gpu
@@ -34,7 +34,7 @@ if [[ "$(basename -- "$0")" == "enable-gpu" ]]; then
 fi
 for cudadir in $cudalibdirs; do
   if [ -e $cudadir ]; then
-    echo Enabling CUDA/GPU using $cudadir
+    echo Enabling CUDA/GPU using $cudadir >&2	#Put on stderr so tools can use stdout
     export  JAVA_OPTIONS="-Djava.library.path=$cudadir $JAVA_OPTIONS"
     export LD_LIBRARY_PATH="$cudadir:$LD_LIBRARY_PATH"
     return

--- a/aisp-core/aisp-core-main/src/main/scripts/label
+++ b/aisp-core/aisp-core-main/src/main/scripts/label
@@ -15,9 +15,9 @@
 # * limitations under the License.
 # *******************************************************************************
 cmd=$0
-CAACLASS=org.eng.aisp.tools.ListModels
+CAACLASS=org.eng.aisp.tools.Label
 if [ -z "$AISP_HOME" ]; then
-   echo Setting AISP_HOME and PATH automatically >&2 # So stdout can be redirected into a .js file
+   echo Setting AISP_HOME and PATH automatically >&2 # To stderr so stdout can be used for redirection .csv file 
    export AISP_HOME=$(cd -P -- "$(dirname -- "$0")" && cd -P .. && pwd -P)
    export PATH=$AISP_HOME/bin:$PATH
 fi

--- a/aisp-core/aisp-core-main/src/main/scripts/label.bat
+++ b/aisp-core/aisp-core-main/src/main/scripts/label.bat
@@ -17,7 +17,7 @@ REM ****************************************************************************
 
 @rem Set local scope for the variables with windows NT shell
 if "%OS%"=="Windows_NT" setlocal
-set CAACLASS=org.eng.aisp.tools.ListModels
+set CAACLASS=org.eng.aisp.tools.Label
 
 REM Try and set AISP_HOME and PATH automatically assuming this script is being run from AISP_HOME/bin
 if NOT [%AISP_HOME%] == [] goto homeset

--- a/aisp-core/aisp-core-main/src/test/java/org/eng/aisp/util/FixedDurationSoundRecordingIterableTest.java
+++ b/aisp-core/aisp-core-main/src/test/java/org/eng/aisp/util/FixedDurationSoundRecordingIterableTest.java
@@ -15,8 +15,14 @@
  *******************************************************************************/
 package org.eng.aisp.util;
 
+import java.util.List;
+import java.util.Properties;
+
 import org.eng.aisp.IDataWindow.PadType;
 import org.eng.aisp.SoundRecording;
+import org.eng.aisp.SoundTestUtils;
+import org.junit.Assert;
+import org.junit.Test;
 
 
 public class FixedDurationSoundRecordingIterableTest extends AbstractFixedDurationLabeledWindowIterableTest {
@@ -25,6 +31,24 @@ public class FixedDurationSoundRecordingIterableTest extends AbstractFixedDurati
 	protected Iterable<SoundRecording> newSubWindowingIterable(Iterable<SoundRecording> recordings, int clipMsec, PadType padType) {
 		FixedDurationSoundRecordingIterable iterable = new FixedDurationSoundRecordingIterable(recordings, clipMsec, padType);
 		return iterable;
+	}
+	
+	@Test
+	public void testSlidingWindows() {
+		int startMsec = 0;
+		int pauseMsec = 0;		// keep this 0 otherwise assert below needs to be adjusted.
+		int htz = 1000;
+		int count = 1;
+		int sourceDurationMsec = 10 * 1000;
+		int clipLen = 1000;
+		int clipShift = 500;
+		PadType padType = PadType.NoPad;
+		Properties p = new Properties();
+		p.setProperty("status", "somevalue");
+		List<SoundRecording> recordings = SoundTestUtils.createTrainingRecordings(count, startMsec, sourceDurationMsec, pauseMsec, htz,p);
+		FixedDurationSoundRecordingIterable iterable = new FixedDurationSoundRecordingIterable(recordings, clipLen, clipShift, padType);
+		List<SoundRecording> subWindows = SoundTestUtils.iterable2List(iterable);
+		Assert.assertTrue(subWindows.size() == 20);
 	}
 
 }

--- a/aisp-core/aisp-core-main/src/test/java/org/eng/aisp/util/FixedDurationSoundRecordingIterableTest.java
+++ b/aisp-core/aisp-core-main/src/test/java/org/eng/aisp/util/FixedDurationSoundRecordingIterableTest.java
@@ -48,7 +48,9 @@ public class FixedDurationSoundRecordingIterableTest extends AbstractFixedDurati
 		List<SoundRecording> recordings = SoundTestUtils.createTrainingRecordings(count, startMsec, sourceDurationMsec, pauseMsec, htz,p);
 		FixedDurationSoundRecordingIterable iterable = new FixedDurationSoundRecordingIterable(recordings, clipLen, clipShift, padType);
 		List<SoundRecording> subWindows = SoundTestUtils.iterable2List(iterable);
-		Assert.assertTrue(subWindows.size() == 20);
+		Assert.assertTrue(subWindows.size() == 20-1);	// The last 1/2 second of the last segment does not start any sub-windows.
+		for (SoundRecording sr : subWindows) 
+			Assert.assertTrue(sr.getDataWindow().getDurationMsec() == clipLen);			
 	}
 
 }

--- a/aisp-core/aisp-core-main/src/test/java/org/eng/aisp/util/FixedDurationSoundRecordingShuffleIterableTest.java
+++ b/aisp-core/aisp-core-main/src/test/java/org/eng/aisp/util/FixedDurationSoundRecordingShuffleIterableTest.java
@@ -127,6 +127,8 @@ public class FixedDurationSoundRecordingShuffleIterableTest extends FixedDuratio
 		IShuffleIterable<SoundRecording> shuffledRecordings = new ShufflizingIterable(recordings);
 		FixedDurationSoundRecordingShuffleIterable iterable = new FixedDurationSoundRecordingShuffleIterable(shuffledRecordings, clipLen, clipShift, padType);
 		List<SoundRecording> subWindows = SoundTestUtils.iterable2List(iterable.shuffle());
-		Assert.assertTrue(subWindows.size() == 20);
+		Assert.assertTrue(subWindows.size() == 20-1);	// The last 1/2 second of the last segment does not start any sub-windows.
+		for (SoundRecording sr : subWindows) 
+			Assert.assertTrue(sr.getDataWindow().getDurationMsec() == clipLen);			
 	}
 }

--- a/aisp-core/aisp-core-main/src/test/java/org/eng/aisp/util/FixedDurationSoundRecordingShuffleIterableTest.java
+++ b/aisp-core/aisp-core-main/src/test/java/org/eng/aisp/util/FixedDurationSoundRecordingShuffleIterableTest.java
@@ -110,4 +110,23 @@ public class FixedDurationSoundRecordingShuffleIterableTest extends FixedDuratio
 		Assert.assertTrue(count == 0); 
 		
 	}
+	
+	@Test
+	public void testSlidingWindows() {
+		int startMsec = 0;
+		int pauseMsec = 0;		// keep this 0 otherwise assert below needs to be adjusted.
+		int htz = 1000;
+		int count = 1;
+		int sourceDurationMsec = 10 * 1000;
+		int clipLen = 1000;
+		int clipShift = 500;
+		PadType padType = PadType.NoPad;
+		Properties p = new Properties();
+		p.setProperty("status", "somevalue");
+		List<SoundRecording> recordings = SoundTestUtils.createTrainingRecordings(count, startMsec, sourceDurationMsec, pauseMsec, htz,p);
+		IShuffleIterable<SoundRecording> shuffledRecordings = new ShufflizingIterable(recordings);
+		FixedDurationSoundRecordingShuffleIterable iterable = new FixedDurationSoundRecordingShuffleIterable(shuffledRecordings, clipLen, clipShift, padType);
+		List<SoundRecording> subWindows = SoundTestUtils.iterable2List(iterable.shuffle());
+		Assert.assertTrue(subWindows.size() == 20);
+	}
 }


### PR DESCRIPTION
New `label` tool with the following help text

```
Classifies sounds using a model to produce a metadata-formatted on stdout.
While the -clipLen option is not strictly required, it is typically used
to classify sub-segments of the input sound(s).  Segments from the same file
that are are adjacent in time and have the same label name as produced by the
the model will be merged.
Classify mode options
  [list of wav files] : specifies 1 or more .wav files without labeling.
     File names are space-separated.  The can not be used with the
     -sounds option.
  -sounds csv list of (dir|metadata.csv) : specifies 1 or more metadata.csv
     files referencing sounds or directories containing a metadata.csv.
     This is an alternative to a list of wav files, but adds labels from
     metadata files.
  -metadata (all|some) : require that all files listed in the metadata file
      to be present. Only used with -sounds option.
      Default does not require all files.
  -clipLen double : splits sound recordings up into clips of the given
      number of milliseconds. Set to 0 to turn off.
      Defaults to 0
  -pad (no|zero|duplicate): when clips are shorter than the requests clip
      padding can be added to make all clips the same length. Some models may
      require this.  Zero padding sets the added samples to zero.  Duplicate
      reuses the sound as many times a necessary to set the added samples.
      No padding removes clips shorter than the requested clip length.
      Default is no padding.
Label examples:
  ... -file myclassifier.cfr -clipLen 1000 number1.wav number2.wav
  ... -file myclassifier.cfr -clipLen 1000 -pad duplicate number1.wav
  ... -file myclassifier.cfr -clipLen 1000 -pad duplicate -sounds metadata.csv
```

Also added -clipShift N option to CLI using -sounds option.