### PR TITLE
Change from nashorn to graal  javascript interpreter, enabling Java 15 and later

### DIFF
--- a/aisp-core/aisp-core-main-cpu/.classpath
+++ b/aisp-core/aisp-core-main-cpu/.classpath
@@ -8,13 +8,8 @@
 	</classpathentry>
 	<classpathentry kind="src" output="target/test-classes" path="src/test/java">
 		<attributes>
-			<attribute name="optional" value="true"/>
-			<attribute name="maven.pomderived" value="true"/>
 			<attribute name="test" value="true"/>
-		</attributes>
-	</classpathentry>
-	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-1.8">
-		<attributes>
+			<attribute name="optional" value="true"/>
 			<attribute name="maven.pomderived" value="true"/>
 		</attributes>
 	</classpathentry>

--- a/aisp-core/aisp-core-main/.classpath
+++ b/aisp-core/aisp-core-main/.classpath
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <classpath>
-	<classpathentry excluding="**" kind="src" output="target/classes" path="src/main/resources">
+	<classpathentry kind="src" output="target/classes" path="src/main/resources">
 		<attributes>
 			<attribute name="maven.pomderived" value="true"/>
 		</attributes>
@@ -13,15 +13,15 @@
 	</classpathentry>
 	<classpathentry kind="src" output="target/test-classes" path="src/test/java">
 		<attributes>
+			<attribute name="test" value="true"/>
 			<attribute name="optional" value="true"/>
 			<attribute name="maven.pomderived" value="true"/>
-			<attribute name="test" value="true"/>
 		</attributes>
 	</classpathentry>
-	<classpathentry excluding="**" kind="src" output="target/test-classes" path="src/test/resources">
+	<classpathentry kind="src" output="target/test-classes" path="src/test/resources">
 		<attributes>
-			<attribute name="maven.pomderived" value="true"/>
 			<attribute name="test" value="true"/>
+			<attribute name="maven.pomderived" value="true"/>
 		</attributes>
 	</classpathentry>
 	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-1.8">

--- a/aisp-core/aisp-core-main/.settings/org.eclipse.wst.common.component
+++ b/aisp-core/aisp-core-main/.settings/org.eclipse.wst.common.component
@@ -1,11 +1,16 @@
 <?xml version="1.0" encoding="UTF-8"?><project-modules id="moduleCoreId" project-version="1.5.0">
-        
-    <wb-module deploy-name="aisp-core-main">
-                
-        <wb-resource deploy-path="/" source-path="/src/main/java"/>
-                
-        <wb-resource deploy-path="/" source-path="/src/main/resources"/>
             
-    </wb-module>
     
+    <wb-module deploy-name="aisp-core-main">
+                        
+        
+        <wb-resource deploy-path="/" source-path="/src/main/java"/>
+                        
+        
+        <wb-resource deploy-path="/" source-path="/src/main/resources"/>
+                    
+    
+    </wb-module>
+        
+
 </project-modules>

--- a/aisp-core/aisp-core-main/.settings/org.eclipse.wst.common.component
+++ b/aisp-core/aisp-core-main/.settings/org.eclipse.wst.common.component
@@ -1,6 +1,11 @@
 <?xml version="1.0" encoding="UTF-8"?><project-modules id="moduleCoreId" project-version="1.5.0">
+        
     <wb-module deploy-name="aisp-core-main">
+                
         <wb-resource deploy-path="/" source-path="/src/main/java"/>
+                
         <wb-resource deploy-path="/" source-path="/src/main/resources"/>
+            
     </wb-module>
+    
 </project-modules>

--- a/aisp-core/aisp-core-main/pom.xml
+++ b/aisp-core/aisp-core-main/pom.xml
@@ -10,7 +10,7 @@
 
 	<artifactId>aisp-core-main</artifactId>
   	<properties>
-		<graalvm.version>21.3.6</graalvm.version>
+		<graalvm.version>21.3.6</graalvm.version> <!-- later versions seem to require a jvm later than 11 -->
 	</properties>
 
 

--- a/aisp-core/aisp-core-main/pom.xml
+++ b/aisp-core/aisp-core-main/pom.xml
@@ -9,6 +9,9 @@
 	</parent>
 
 	<artifactId>aisp-core-main</artifactId>
+  	<properties>
+		<graalvm.version>21.3.6</graalvm.version>
+	</properties>
 
 
 	<build>
@@ -140,14 +143,43 @@
 			<version>2.1</version>
 			<scope>compile</scope>
 		</dependency>
-
+        <dependency>
+            <groupId>org.graalvm.sdk</groupId>
+            <artifactId>graal-sdk</artifactId>
+            <version>${graalvm.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.graalvm.js</groupId>
+            <artifactId>js</artifactId>
+            <version>${graalvm.version}</version>
+            <scope>runtime</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.graalvm.js</groupId>
+            <artifactId>js-scriptengine</artifactId>
+            <version>${graalvm.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.graalvm.tools</groupId>
+            <artifactId>profiler</artifactId>
+            <version>${graalvm.version}</version>
+            <scope>runtime</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.graalvm.tools</groupId>
+            <artifactId>chromeinspector</artifactId>
+            <version>${graalvm.version}</version>
+            <scope>runtime</scope>
+        </dependency>
+  
 
 		<!--  
   	#################### Testing dependencies ##############
   	-->
 		<dependency>
 			<groupId>org.reflections</groupId>
-			<artifactId>reflections</artifactId>
+			<artifactId>
+				reflections</artifactId>
 			<version>0.9.10</version>
 			<scope>test</scope>
 		</dependency>

--- a/aisp-core/aisp-core-main/src/main/java/org/eng/aisp/AbstractDataWindow.java
+++ b/aisp-core/aisp-core-main/src/main/java/org/eng/aisp/AbstractDataWindow.java
@@ -226,7 +226,7 @@ public abstract class AbstractDataWindow<WINDATA> extends InstanceIdentifiedObje
 			if (index > maxIndex)
 				index = maxIndex;
 		} else {				// If an upper bound of a window, then compute the index <= this time.
-			index = (int)(msecOffset * samplesPerMsec) ; 	// Index of 1st sample after requested offset.
+			index = (int)(msecOffset * samplesPerMsec + .5) ; 	// Index of 1st sample after requested offset.
 		}
 		return index;
 		

--- a/aisp-core/aisp-core-main/src/main/java/org/eng/aisp/util/JScriptBuilder.java
+++ b/aisp-core/aisp-core-main/src/main/java/org/eng/aisp/util/JScriptBuilder.java
@@ -62,7 +62,7 @@ public class JScriptBuilder {
 	/** String containing all Java import statements automatically included in all scripts before executing */
 	protected static List<String> AVAILABLE_CLASSES_FOR_IMPORT = null;
 	protected final String script;
-	private final JScriptEngine jsEngine = new JScriptEngine(null);
+	private final JScriptEngine jsEngine = new JScriptEngine();
 	protected final Map<String,Object> bindings;
 	private Class<?>[] resultClasses;
 	private final String[] preferredResultVarNames;

--- a/aisp-core/aisp-core-main/src/main/java/org/eng/aisp/util/JScriptBuilder.java
+++ b/aisp-core/aisp-core-main/src/main/java/org/eng/aisp/util/JScriptBuilder.java
@@ -234,13 +234,13 @@ public class JScriptBuilder {
 		
 		try {
 //			AISPLogger.logger.info("Script is...\n" + script);
-			this.jsEngine.runScript(script, bindings, true);
+			this.jsEngine.runScript(script, bindings, false, false);
 			for (int i=0; i<resultClasses.length ; i++) {
 				String varName = preferredResultVarNames[i];
 				Class<?> resultClass = resultClasses[i];
-				Object result = this.jsEngine.getScriptVariable(resultClass, varName);
+				Object result = this.jsEngine.getScriptVariable(resultClass, varName, false);
 				if (result == null) 
-					result = this.jsEngine.getScriptVariable(resultClass, null);
+					result = this.jsEngine.getScriptVariable(resultClass, null, false);
 				if (result == null) 
 					throw new AISPException("Script did not create an instance of " + resultClass.getName());
 				results.put(varName,  result);

--- a/aisp-core/aisp-core-main/src/main/java/org/eng/aisp/util/JScriptEngine.java
+++ b/aisp-core/aisp-core-main/src/main/java/org/eng/aisp/util/JScriptEngine.java
@@ -21,6 +21,7 @@ import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.function.Predicate;
 
 import javax.script.Bindings;
 import javax.script.ScriptContext;
@@ -43,7 +44,22 @@ public class JScriptEngine {
 //			if (engine == null && requireSecurity) 
 //				throw new IllegalArgumentException("Could not enable security");
 //		} else {
-			engine = new ScriptEngineManager().getEngineByName("nashorn");
+			System.setProperty("polyglot.engine.WarnInterpreterOnly", "false");	// Turn off graal interpreter warnings below
+//			[To redirect Truffle log output to a file use one of the following options:
+//			* '--log.file=<path>' if the option is passed using a guest language launcher.
+//			* '-Dpolyglot.log.file=<path>' if the option is passed using the host Java launcher.
+//			* Configure logging using the polyglot embedding API.]
+//			[engine] WARNING: The polyglot context is using an implementation that does not support runtime compilation.
+//			The guest application code will therefore be executed in interpreted mode only.
+//			Execution only in interpreted mode will strongly impact the guest application performance.
+//			For more information on using GraalVM see https://www.graalvm.org/java/quickstart/.
+//			To disable this warning the '--engine.WarnInterpreterOnly=false' option or use the '-Dpolyglot.engine.WarnInterpreterOnly=false' system property.
+			ScriptEngineManager sem= new ScriptEngineManager();
+//			List<ScriptEngineFactory> sef = sem.getEngineFactories();
+			engine = sem.getEngineByName("JavaScript");	// The graal engine (not graal.js apparently).
+			Bindings bindings = engine.getBindings(ScriptContext.ENGINE_SCOPE);
+			bindings.put("polyglot.js.allowHostAccess", true);
+			bindings.put("polyglot.js.allowHostClassLookup", (Predicate<String>) s -> true);
 //		}
 	}
 	
@@ -121,24 +137,24 @@ public class JScriptEngine {
 		if (scriptObj == null)
 			return null;
 		
-	    if (scriptObj instanceof jdk.nashorn.api.scripting.ScriptObjectMirror) {
-	    	jdk.nashorn.api.scripting.ScriptObjectMirror scriptObjectMirror = (jdk.nashorn.api.scripting.ScriptObjectMirror) scriptObj;
-	        if (scriptObjectMirror.isArray()) {
-	            List<Object> list = new ArrayList<Object>(); 
-	            for (Map.Entry<String, Object> entry : scriptObjectMirror.entrySet()) {
-	                list.add(toJava(entry.getValue()));
-	            }
-	            return list;
-	        } else {
-	            Map<String, Object> map = new HashMap<String,Object>(); 
-	            for (Map.Entry<String, Object> entry : scriptObjectMirror.entrySet()) {
-	                map.put(entry.getKey(), toJava(entry.getValue()));
-	            }
-	            return map;
-	        }
-	    } else {
+//	    if (scriptObj instanceof jdk.nashorn.api.scripting.ScriptObjectMirror) {
+//	    	jdk.nashorn.api.scripting.ScriptObjectMirror scriptObjectMirror = (jdk.nashorn.api.scripting.ScriptObjectMirror) scriptObj;
+//	        if (scriptObjectMirror.isArray()) {
+//	            List<Object> list = new ArrayList<Object>(); 
+//	            for (Map.Entry<String, Object> entry : scriptObjectMirror.entrySet()) {
+//	                list.add(toJava(entry.getValue()));
+//	            }
+//	            return list;
+//	        } else {
+//	            Map<String, Object> map = new HashMap<String,Object>(); 
+//	            for (Map.Entry<String, Object> entry : scriptObjectMirror.entrySet()) {
+//	                map.put(entry.getKey(), toJava(entry.getValue()));
+//	            }
+//	            return map;
+//	        }
+//	    } else {
 	        return scriptObj;
-	    }
+//	    }
 	}
 	
 	/**

--- a/aisp-core/aisp-core-main/src/main/java/org/eng/aisp/util/JScriptEngine.java
+++ b/aisp-core/aisp-core-main/src/main/java/org/eng/aisp/util/JScriptEngine.java
@@ -164,6 +164,8 @@ public class JScriptEngine {
 				newObject = tryPolyglotAsMap(scriptObj);
 			if (newObject != null)	// else probably fail later.
 				scriptObj = newObject;
+			else
+				AISPLogger.logger.warning("Could not convert object of class " + className);
 		} else if ( className.equals("com.oracle.truffle.polyglogObjectProxyHandler")) {
 			AISPLogger.logger.info("scriptObj=" + scriptObj.toString());
 		} else if ( className.equals("com.oracle.truffle.js.scriptengine.GraalJSBindings")) {
@@ -191,6 +193,38 @@ public class JScriptEngine {
 		return newObject;
 	}
 
+//	private static String toJson(Object scriptObj) {
+//		List list = tryPolyglotAsList(scriptObj);
+//		if (list != null)
+//			return gson.toJson(list);
+//		if (scriptObj instanceof Map) {
+//			Map map = (Map)scriptObj; 
+//			StringBuilder sb = null;
+//			for (Object key : map.keySet()) {
+//				if (sb == null) {
+//					sb = new StringBuilder();
+//					sb.append("{ ");
+//				} else {
+//					sb.append(", ");
+//				}
+//				Object value = map.get(key);
+//				String keyString = toJson(key);
+//				String valueString = toJson(value);
+//				sb.append(keyString);
+//				sb.append(" : ");
+//				sb.append(valueString);
+//			}
+//			sb.append(" }");
+//			return sb.toString();
+//		} else if (scriptObj instanceof Number) {
+//			return scriptObj.toString();
+//		} else if (scriptObj instanceof String) {
+//			return "\"" + scriptObj.toString() + "\"";
+//		} else {
+//			AISPLogger.logger.warning("Unexpected object type " + scriptObj.getClass().getName());
+//			return gson.toJson(scriptObj);
+//		}
+//	}
 	/**
 	 * Try and convert the given PolyglotMap instance to a Map.
 	 * @param polyglot
@@ -218,7 +252,9 @@ public class JScriptEngine {
 		// This seems to help use avoid treating polyglot object as Map below, when values are Proxy$ instances.
 		// Leaving values as $Proxy is bad since they don't seem to be serializable.
 		try {
+			// TODO: this fails for long values when toString() starts to abbreviate values.
 			json = polyglot.toString();
+//			json = toJson(polyglot);
 			Map map = gson.fromJson(json, Map.class);
 			newObject = convertMap(map);
 			return newObject;

--- a/aisp-core/aisp-core-main/src/main/java/org/eng/aisp/util/JScriptEngine.java
+++ b/aisp-core/aisp-core-main/src/main/java/org/eng/aisp/util/JScriptEngine.java
@@ -143,25 +143,8 @@ public class JScriptEngine {
 		if (scriptObj == null)
 			return null;
 		
-//	    if (scriptObj instanceof jdk.nashorn.api.scripting.ScriptObjectMirror) {
-//	    	jdk.nashorn.api.scripting.ScriptObjectMirror scriptObjectMirror = (jdk.nashorn.api.scripting.ScriptObjectMirror) scriptObj;
-//	        if (scriptObjectMirror.isArray()) {
-//	            List<Object> list = new ArrayList<Object>(); 
-//	            for (Map.Entry<String, Object> entry : scriptObjectMirror.entrySet()) {
-//	                list.add(toJava(entry.getValue()));
-//	            }
-//	            return list;
-//	        } else {
-//	            Map<String, Object> map = new HashMap<String,Object>(); 
-//	            for (Map.Entry<String, Object> entry : scriptObjectMirror.entrySet()) {
-//	                map.put(entry.getKey(), toJava(entry.getValue()));
-//	            }
-//	            return map;
-//	        }
-//	    } else {
 		String className = scriptObj.getClass().getName();
-		ENGLogger.logger.info("class=" + className);
-//		com.oracle.truffle.js.scriptengine.GraalJSBindings b;
+//		ENGLogger.logger.info("class=" + className);
 
 		if (className.equals("com.oracle.truffle.polyglot.PolyglotMap")) {
 			// We need to convert the map to a serializable map, including its contents.
@@ -224,33 +207,7 @@ public class JScriptEngine {
 		
 		jsObj = toJava(jsObj);
 		
-//		if (Map.class.isAssignableFrom(klass)) {
-//			// Lists/arrays come back as ScriptMirrorObject in Nashorn.  Try and parse them out.
-//			if (!(jsObj instanceof jdk.nashorn.api.scripting.ScriptObjectMirror))
-//				return null;
-//			jdk.nashorn.api.scripting.ScriptObjectMirror mirror = (jdk.nashorn.api.scripting.ScriptObjectMirror)jsObj;
-//			@SuppressWarnings("rawtypes")
-//			Map<Object , Object>  vlist = mirror.to(Map.class); 
-//
-////			Map<Object , Object>  vlist = new HashMap<Object,Object>(); 
-////			for (Object key : mirror.keySet()) {
-////				Object value = mirror.get(key);
-//////				value = convertBestMatch(value);
-////				vlist.put(key, value);
-////			}
-//			return (T)vlist;
-//		} else if (List.class.isAssignableFrom(klass)) {
-//			// Lists/arrays come back as ScriptMirrorObject in Nashorn.  Try and parse them out.
-//			if (!(jsObj instanceof jdk.nashorn.api.scripting.ScriptObjectMirror))
-//				return null;
-//			jdk.nashorn.api.scripting.ScriptObjectMirror mirror = (jdk.nashorn.api.scripting.ScriptObjectMirror)jsObj;
-//			if (!mirror.isArray())
-//				return null;
-//			@SuppressWarnings("rawtypes")
-//			List vlist = mirror.to(List.class); 
-//			return (T)vlist;
-//		} else 
-			if (klass.isAssignableFrom(jsObj.getClass()))  {
+		if (klass.isAssignableFrom(jsObj.getClass()))  {
 			return (T)jsObj;
 		} else  {
 			return null;

--- a/aisp-core/aisp-core-main/src/main/java/org/eng/aisp/util/JScriptEngine.java
+++ b/aisp-core/aisp-core-main/src/main/java/org/eng/aisp/util/JScriptEngine.java
@@ -39,6 +39,14 @@ public class JScriptEngine {
 	private final ScriptEngine engine;
 //	private final List<String> allowedClasses;
 
+	/**
+	 * @param allowedClasses
+	 * @deprecated in favor of {@link JScriptEngine#JScriptEngine()} since we don't support this and haven't for some time.
+	 */
+	public JScriptEngine(List<String> allowedClasses) {
+		this();
+	}
+
 	public JScriptEngine() {
 //		this.allowedClasses = allowedClasses;
 //		if (allowedClasses != null) {
@@ -85,6 +93,7 @@ public class JScriptEngine {
 //		return null;
 //		
 //	}
+
 
 	public Map<String,Object> runScript(File jsFile, Map<String, Object> bindings, boolean clearBindings) throws ScriptException, IOException {
 		String source = FileUtils.readTextFileIntoString(jsFile.getAbsolutePath());

--- a/aisp-core/aisp-core-main/src/main/java/org/eng/aisp/util/JScriptEngine.java
+++ b/aisp-core/aisp-core-main/src/main/java/org/eng/aisp/util/JScriptEngine.java
@@ -17,6 +17,7 @@ package org.eng.aisp.util;
 
 import java.io.File;
 import java.io.IOException;
+import java.io.Serializable;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -68,33 +69,15 @@ public class JScriptEngine {
 //			To disable this warning the '--engine.WarnInterpreterOnly=false' option or use the '-Dpolyglot.engine.WarnInterpreterOnly=false' system property.
 			ScriptEngineManager sem= new ScriptEngineManager();
 //			List<ScriptEngineFactory> sef = sem.getEngineFactories();
-			engine = sem.getEngineByName("JavaScript");	// The graal engine (not graal.js apparently).
+//			engine = sem.getEngineByName("JavaScript");	// The graal engine (not graal.js apparently).
+			engine = sem.getEngineByName("graal.js");	// The graal engine (not graal.js apparently).
 			Bindings bindings = engine.getBindings(ScriptContext.ENGINE_SCOPE);
 			bindings.put("polyglot.js.allowHostAccess", true);
 			bindings.put("polyglot.js.allowHostClassLookup", (Predicate<String>) s -> true);
 //		}
 	}
 	
-//	private final static String SecureEngineFactoryClass = "jdk.nashorn.api.scripting.NashornScriptEngineFactory";
-//  See https://docs.oracle.com/javase/8/docs/technotes/guides/scripting/nashorn/api.html
-//	private static ScriptEngine createSecuredEngine(List<String> allowedClasses) {
-//		try { 
-////			NashornScriptEngineFactory factory = new NashornScriptEngineFactory(); 
-//			Class klazz = Class.forName(SecureEngineFactoryClass);
-//			Object obj = klazz.newInstance();
-//			if (obj instanceof ScriptEngineFactory){
-//				ScriptEngineFactory factory = (ScriptEngineFactory)obj;
-//				factory.
-//				ScriptEngine engine = factory.getScriptEngine(
-//		    	      new MyClassFilterTest.MyCF());
-//		} catch (Exception e) {
-//			AISPLogger.logger.severe("Could not load secure engine class " + SecureEngineFactoryClass 
-//					+ ". Restricting access to following classes is not available: " + allowedClasses);
-//			e.printStackTrace();
-//		}
-//		return null;
-//		
-//	}
+
 
 
 	public Map<String,Object> runScript(File jsFile, Map<String, Object> bindings, boolean clearBindings) throws ScriptException, IOException {
@@ -102,8 +85,30 @@ public class JScriptEngine {
 		return runScript(source, bindings, clearBindings);
 	}
 
+	/**
+	 * A convenience on {@link #runScript(String, Map, boolean, boolean)} with conversion of bindings to Serializable.
+	 * @param source
+	 * @param bindings
+	 * @param clearBindings
+	 * @return
+	 * @throws ScriptException
+	 */
 	public Map<String,Object> runScript(String source, Map<String, Object> bindings, boolean clearBindings) throws ScriptException {
+		return this.runScript(source, bindings, clearBindings, true);
+	}
+
+	public Map<String,Object> runScript(String source, Map<String, Object> bindings, boolean clearBindings, boolean convertToSerializable) throws ScriptException {
 //		System.out.println("executing js source:" + source);
+		bindings = runScriptForBindings(source, bindings, clearBindings);
+		if (convertToSerializable)
+			bindings = (Map<String,Object>)makeSerializable(bindings);
+		return bindings;
+
+	}
+
+
+	private Map<String, Object> runScriptForBindings(String source, Map<String, Object> bindings,
+			boolean clearBindings) throws ScriptException {
 		Bindings engineBindings; 
 		if (clearBindings) 
 			engineBindings = engine.createBindings(); 
@@ -116,9 +121,19 @@ public class JScriptEngine {
 		}
 		engine.setBindings(engineBindings, ScriptContext.ENGINE_SCOPE);
 		engine.eval(source);
+		
+		// For Graal the values returned here may be instances of PolyglotMap. 
 		bindings = engine.getBindings(ScriptContext.ENGINE_SCOPE);
-		return (Map<String,Object>)toJava(bindings);
 
+		// Extract the real Java objects (i.e. avoid PolyglotMap). 
+		Map<String,Object> map = new HashMap<>();
+		for (String key : bindings.keySet()) {
+			// This get() seems to convert/get the actual underlying Java object created in Javascript,
+			// which is otherwise a PolyglotMap which we don't want to return as a value in the returned map.
+			Object obj = bindings.get(key);
+			map.put(key, obj);
+		}
+		return map;
 	}
 	
 	/**
@@ -128,18 +143,15 @@ public class JScriptEngine {
 	 * @return null if not found.
 	 */
 	@SuppressWarnings("unchecked")
-	private static <T> T getInstance(Map<String, Object> bindings, Class<T> klass) {
+	private static <T> T getInstance(Map<String, Object> bindings, Class<T> klass, boolean convertToSerializable) {
 		T value = null;
 		for (String key : bindings.keySet()) {
 			Object o = bindings.get(key);
-			value = getTypeMatchedInstance(o, klass);
+			value = getTypeMatchedInstance(o, klass, convertToSerializable);
 			if (value != null)
-//			if (o != null && klass.isAssignableFrom(o.getClass())) {
-//				value = (T)o;
-				break;
-//			}
+				return value;
 		}
-		return value;
+		return null;
 	}
 
 	private static final Gson gson = new Gson();
@@ -150,9 +162,10 @@ public class JScriptEngine {
 	 * including objects nested in Map or List objects.
 	 * @param scriptObj
 	 * @return a Java object
+	 * @throws ScriptException 
 	 */
-	private static Object toJava(Object scriptObj) {
-		if (scriptObj == null)
+	private static Object makeSerializable(Object scriptObj) throws ScriptException {
+		if (scriptObj == null) 
 			return null;
 		
 		String className = scriptObj.getClass().getName();
@@ -161,18 +174,23 @@ public class JScriptEngine {
 		if (className.equals("com.oracle.truffle.polyglot.PolyglotMap")) {
 			Object newObject = tryPolyglotAsList(scriptObj); 
 			if (newObject == null)
-				newObject = tryPolyglotAsMap(scriptObj);
+				newObject = polyglotAsMap(scriptObj);
 			if (newObject != null)	// else probably fail later.
 				scriptObj = newObject;
 			else
 				AISPLogger.logger.warning("Could not convert object of class " + className);
-		} else if ( className.equals("com.oracle.truffle.polyglogObjectProxyHandler")) {
-			AISPLogger.logger.info("scriptObj=" + scriptObj.toString());
+//		} else if ( className.equals("com.oracle.truffle.polyglogObjectProxyHandler")) {
+//			AISPLogger.logger.info("scriptObj=" + scriptObj.toString());
 		} else if ( className.equals("com.oracle.truffle.js.scriptengine.GraalJSBindings")) {
-			Map map = (Map)scriptObj; 
-			Map<Object, Object> newMap = convertMap(map);
-			scriptObj = newMap;
-		} 
+			scriptObj = makeMapSerializable((Map)scriptObj);
+		}  else if (scriptObj instanceof Map) {	// Make sure all values are also java objects. 
+			scriptObj = makeMapSerializable((Map)scriptObj);
+		}
+		
+		if (!(scriptObj instanceof Serializable))
+			throw new ScriptException("Object of class " + scriptObj.getClass().getName() 
+					+ " could not be converted to Serializable");
+		
 	    return scriptObj;
 	}
 
@@ -182,55 +200,60 @@ public class JScriptEngine {
 	 */
 	private static Pattern listValuePattern = Pattern.compile("^\\(\\d+\\)\\[");
 
-	private static List<?> tryPolyglotAsList(Object scriptObj) {
+	private static List<?> tryPolyglotAsList(Object scriptObj) throws ScriptException {
 		List<?> newObject = null;
 		String value = scriptObj.toString();
 		Matcher m = listValuePattern.matcher(value);
 		if (m.find()) {
 			value = m.replaceAll("[");
-			newObject = gson.fromJson(value, List.class);;
+			// If it is a list of non-primitives, in particular Java objects, they are not serialized with our toJson().
+			// toString() produces somethign like the following when this is the case.
+			// (5)[JavaObject[org.eng.aisp.classifier.gmm.GMMClassifierBuilder], 
+			// for an eventual answer, hopefully.
+			// Note that if we use Bindings.get(<varname>) the actual object does come back, but not here when we don't have and engine instance.
+			// See runScriptForBindings() for usage the extracts the Java object created in JavaScript.
+			// Also note, that the same thing would happen in polyglotAsMap(), its just that so far our scripts have not put our Java objects in maps. 
+			// For now we don't see a way to support this.
+			// See https://stackoverflow.com/questions/76466839/how-do-i-convert-objects-created-in-graal-javascript-to-serializable-java-object
+			String json; 
+			if (value.contains("JavaObject")) {
+				throw new ScriptException("Can not convert Java objects");
+			} else {
+				json = toJson(scriptObj);
+			}
+			newObject = gson.fromJson(json, List.class);
 		}
 		return newObject;
 	}
 
-//	private static String toJson(Object scriptObj) {
-//		List list = tryPolyglotAsList(scriptObj);
-//		if (list != null)
-//			return gson.toJson(list);
-//		if (scriptObj instanceof Map) {
-//			Map map = (Map)scriptObj; 
-//			StringBuilder sb = null;
-//			for (Object key : map.keySet()) {
-//				if (sb == null) {
-//					sb = new StringBuilder();
-//					sb.append("{ ");
-//				} else {
-//					sb.append(", ");
-//				}
-//				Object value = map.get(key);
-//				String keyString = toJson(key);
-//				String valueString = toJson(value);
-//				sb.append(keyString);
-//				sb.append(" : ");
-//				sb.append(valueString);
-//			}
-//			sb.append(" }");
-//			return sb.toString();
-//		} else if (scriptObj instanceof Number) {
-//			return scriptObj.toString();
-//		} else if (scriptObj instanceof String) {
-//			return "\"" + scriptObj.toString() + "\"";
-//		} else {
-//			AISPLogger.logger.warning("Unexpected object type " + scriptObj.getClass().getName());
-//			return gson.toJson(scriptObj);
-//		}
-//	}
+
+	
+	/**
+	 * Convert the given script-created object to a json string.
+	 * The implementation does NOT use Gson since its toJson() methods throws a ClassNotFoundException on ThreadMXBean class.
+	 * Instead, use JavaScript's JSON.stringify() to convert object to json string. 
+	 * @param scriptObj
+	 * @return never null
+	 * @throws ScriptException
+	 */
+	private static String toJson(Object scriptObj) throws ScriptException {
+		JScriptEngine engine = new JScriptEngine();
+		String script = "var json = JSON.stringify(obj)";
+		Map<String,Object> bindings = new HashMap<>();
+		bindings.put("obj", scriptObj);
+		Map<String,Object> result = engine.runScriptForBindings(script, bindings, false);
+		Object json = result.get("json");
+		json = json.toString();
+		return (String)json;
+	}
+	
 	/**
 	 * Try and convert the given PolyglotMap instance to a Map.
 	 * @param polyglot
 	 * @return null if could not be converted.
+	 * @throws ScriptException 
 	 */
-	private static Map tryPolyglotAsMap(Object polyglot) {
+	private static Map polyglotAsMap(Object polyglot) throws ScriptException {
 		// We need to convert the map to a serializable map, including its contents.
 		// The PolygloMap was found to contain a Proxy$<N> object which contains another truffle class. Yuck!
 		// So try to work with a json formatting of the map.
@@ -239,24 +262,12 @@ public class JScriptEngine {
 		Map newObject = null;
 		String json; 
 
-		// We could do this as it might be more efficient, but the toString() version below seems to be sufficient.
-//		try {
-//			json = gson.toJson(polyglot);	// This throws  java.lang.ClassNotFoundException: com.sun.management.ThreadMXBean
-//			Map map = gson.fromJson(json, Map.class);
-//			newObject = convertMap(map);
-//			return newObject;
-//		} catch (Throwable e) { 
-//			;
-//		}
-
 		// This seems to help use avoid treating polyglot object as Map below, when values are Proxy$ instances.
 		// Leaving values as $Proxy is bad since they don't seem to be serializable.
 		try {
-			// TODO: this fails for long values when toString() starts to abbreviate values.
-			json = polyglot.toString();
-//			json = toJson(polyglot);
+			json = toJson(polyglot);
 			Map map = gson.fromJson(json, Map.class);
-			newObject = convertMap(map);
+			newObject = makeMapSerializable(map);
 			return newObject;
 		} catch (Exception e) { 
 			;
@@ -264,41 +275,66 @@ public class JScriptEngine {
 
 		// Try this last 
 		if (newObject == null && polyglot instanceof Map) 
-			newObject = convertMap((Map)polyglot); 
+			newObject = makeMapSerializable((Map)polyglot); 
 		return newObject;
 	}
 	
 	
-	protected static Map<Object, Object> convertMap(Map map) {
+	private static Map<Object, Object> makeMapSerializable(Map map) throws ScriptException {
 		Map<Object,Object> newMap = new HashMap<>();
 		for (Object key : map.keySet()) {
 			Object value = map.get(key);
-			Object newKey = toJava(key);
-			Object newValue = toJava(value);
+			Object newKey = makeSerializable(key);
+			Object newValue = makeSerializable(value);
 			newMap.put(newKey, newValue);
 		}
 		return newMap;
 	}
 	
 	/**
+	 * A convenience on {@link #getTypeMatchedInstance(Object, Class, boolean)} with serializability conversion.
+	 * @param <T>
+	 * @param jsObj
+	 * @param klass
+	 * @return
+	 * @deprecated in favor of {@link #getTypeMatchedInstance(Object, Class, boolean)}
+	 */
+	@SuppressWarnings({ "restriction", "unchecked" })
+	public static <T> T getTypeMatchedInstance(Object jsObj, Class<T> klass) {
+		return getTypeMatchedInstance(jsObj, klass, true);
+	}
+
+	/**
 	 * Try and extract an instance of the given class from the given object retrieved from JavaScript bindings.
 	 * @param <T>
 	 * @param jsObj object retrieved from JavaScript bindings
 	 * @param klass class to convert the object to and return an instance of.
-	 * @return null if object could not be converted to an instance of the given class or is given as null.
+	 * @param convertToSerializable if true, then make sure the obj value is serializable or fail in the conversion and return null.
+	 * @return null if object could not be converted to an instance of the given class, serializability is requested but could not be converted, or is given as null.
 	 */
 	@SuppressWarnings({ "restriction", "unchecked" })
-	public static <T> T getTypeMatchedInstance(Object jsObj, Class<T> klass) {
+	public static <T> T getTypeMatchedInstance(Object jsObj, Class<T> klass, boolean convertToSerializable) {
 		if (jsObj == null)
 			return null;
 		
-		jsObj = toJava(jsObj);
+		if (convertToSerializable) {
+			try {
+				jsObj = makeSerializable(jsObj);
+			} catch (ScriptException e) {
+				return null;
+			}
+		}
 		
 		if (klass.isAssignableFrom(jsObj.getClass()))  {
 			return (T)jsObj;
 		} else  {
 			return null;
 		}
+	}
+
+	@SuppressWarnings("unchecked")
+	public <T> T getScriptVariable(Class<T> klass, String varName) throws AISPException {
+		return getScriptVariable(klass, varName, true);
 	}
 		
 	/**
@@ -309,18 +345,18 @@ public class JScriptEngine {
 	 * @throws AISPException found, but not of the requested type. 
 	 */
 	@SuppressWarnings("unchecked")
-	public <T> T getScriptVariable(Class<T> klass, String varName) throws AISPException {
+	public <T> T getScriptVariable(Class<T> klass, String varName, boolean convertToSerializable) throws AISPException {
 		Bindings bindings = engine.getBindings(ScriptContext.ENGINE_SCOPE);
 		T value;
 		if (varName != null) {
 			Object obj = bindings.get(varName);
-			value = getTypeMatchedInstance(obj, klass);
+			value = getTypeMatchedInstance(obj, klass, convertToSerializable);
 			if (value == null) 
 				throw new AISPException("Variable with name '" + varName + "' is not of the expected type (" + klass.getName() 
 				+ ") or can not be converted.");
 		} else {
 			// Search all bindings
-			value = getInstance(bindings, klass);
+			value = getInstance(bindings, klass, convertToSerializable);
 		}
 		return (T)value;
 	}
@@ -332,8 +368,8 @@ public class JScriptEngine {
 	 * @param dflt the default value to return if no variable was found matching the request. 
 	 * @return the value from the script or the default value.
 	 */
-	public <T> T getScriptVariable(Class<T> klass, String varName, T dflt) throws AISPException {
-		T value = getScriptVariable(klass, varName);
+	public <T> T getScriptVariable(Class<T> klass, String varName, T dflt, boolean convertToSerializable) throws AISPException {
+		T value = getScriptVariable(klass, varName, convertToSerializable);
 
 		// Check to see if we should use the default value given.
 		if (value == null) {

--- a/aisp-core/aisp-core-main/src/test/java/org/eng/aisp/classifier/factory/ClassifierFactoriesTest.java
+++ b/aisp-core/aisp-core-main/src/test/java/org/eng/aisp/classifier/factory/ClassifierFactoriesTest.java
@@ -38,6 +38,7 @@ import org.eng.aisp.classifier.gmm.GMMClassifier;
 import org.eng.aisp.classifier.knn.merge.EuclidianDistanceMergeKNNClassifier;
 import org.eng.aisp.classifier.knn.merge.L1DistanceMergeKNNClassifier;
 import org.eng.aisp.classifier.knn.merge.LpDistanceMergeKNNClassifier;
+import org.eng.util.ClassUtilities;
 import org.junit.Assert;
 import org.junit.Test;
 import org.reflections.Reflections;
@@ -73,12 +74,24 @@ public class ClassifierFactoriesTest {
 		for (String js : fileNames) {
 			String baseName = js.replaceAll("\\" + extension, "");
 			baseName = new File(baseName).getName();
+			IClassifier<double[]> classifier = null; 
 			try {
 //				 System.out.println("loading " + baseName);
-				IClassifier<double[]> classifier = ClassifierFactories.newDefaultClassifier(baseName);
+				classifier = ClassifierFactories.newDefaultClassifier(baseName);
 				Assert.assertTrue(classifier != null);
 			} catch (Exception e) { // Catch so we can show which js file failed.
 				Assert.fail("Could not create classifier for name " + baseName + ": " + e.getMessage());
+			}
+			// Also make sure the (untrained) classifier created via JavaScript is serializable since,
+			// when porting to use Graal, we initially had cases where the maps  passed to classifier constructors were not serializable.
+			try {
+				if (classifier != null)
+					ClassUtilities.serialize(classifier);
+				else
+					Assert.fail("Not expected to get to this line");
+			} catch (Exception e) {
+				Assert.fail("Could serialize classifier for name name " + baseName + ": " + e.getMessage());
+				
 			}
 		}
 	}

--- a/aisp-core/aisp-core-main/src/test/java/org/eng/aisp/classifier/factory/ClassifierFactoriesTest.java
+++ b/aisp-core/aisp-core-main/src/test/java/org/eng/aisp/classifier/factory/ClassifierFactoriesTest.java
@@ -137,7 +137,7 @@ public class ClassifierFactoriesTest {
 			Map<String,Object> bindings = new HashMap<String,Object>();
 			bindings.put("distanceMetric", "Lp");
 			bindings.put("maxListSize", size); 
-			for ( String multiplier : trueFalse)  {
+			for ( float multiplier : multipliers)  {
 				bindings.put("stddevMultiplier", multiplier); 
 				for ( String outliers : trueFalse)  {
 					bindings.put("enableOutliers", outliers); 

--- a/aisp-core/aisp-core-main/src/test/java/org/eng/util/ENGUtilTestSuite.java
+++ b/aisp-core/aisp-core-main/src/test/java/org/eng/util/ENGUtilTestSuite.java
@@ -30,7 +30,8 @@ import org.junit.runners.Suite;
 	IthShuffleIterableTest2.class,
 	ShufflizingIterableTest.class,
 	ItemReferenceIteratorTest.class,
-	ShufflizingItemReferenceIterableProxyTest.class
+	ShufflizingItemReferenceIterableProxyTest.class,
+	JScriptEngineTest.class
 })
 	
 public class ENGUtilTestSuite {

--- a/aisp-core/aisp-core-main/src/test/java/org/eng/util/JScriptEngineTest.java
+++ b/aisp-core/aisp-core-main/src/test/java/org/eng/util/JScriptEngineTest.java
@@ -25,7 +25,7 @@ public class JScriptEngineTest {
 
 	@Test
 	public void testListReturnType() throws ScriptException {
-		String value = "[ 1, 2, 3 ]";
+		String value = "[ 1.1, 2.1, 3.1 ]";
 		Class<List> clazz = List.class;
 		variableTest(value, clazz);
 	}

--- a/aisp-core/aisp-core-main/src/test/java/org/eng/util/JScriptEngineTest.java
+++ b/aisp-core/aisp-core-main/src/test/java/org/eng/util/JScriptEngineTest.java
@@ -1,0 +1,86 @@
+package org.eng.util;
+
+import java.io.Serializable;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import javax.script.ScriptException;
+
+import org.eng.aisp.util.JScriptEngine;
+import org.junit.Assert;
+import org.junit.Test;
+
+import com.google.gson.Gson;
+
+public class JScriptEngineTest {
+	private static Gson gson = new Gson();
+	
+	@Test
+	public void testMapReturnType() throws ScriptException {
+		String value = "{ \"a\" : 1.0, \"b\" : \"str\", \"c\" : { \"d\" : 2.0 } }";
+		Class<Map> clazz = Map.class;
+		variableTest(value, clazz);
+	}
+
+	@Test
+	public void testListReturnType() throws ScriptException {
+		String value = "[ 1, 2, 3 ]";
+		Class<List> clazz = List.class;
+		variableTest(value, clazz);
+	}
+
+	@Test
+	public void testIntegerReturnType() throws ScriptException {
+		String value = "3";
+		Class<Integer> clazz = Integer.class;
+		variableTest(value, clazz);
+	}
+
+	@Test
+	public void testDoubleReturnType() throws ScriptException {
+		String value = "3.1";
+		Class<Double> clazz = Double.class;
+		variableTest(value, clazz);
+	}
+
+	@Test
+	public void testStringReturnType() throws ScriptException {
+		String value = "\"string\"";
+		Class<String> clazz = String.class;
+		variableTest(value, clazz);
+	}
+	
+	/**
+	 * Assign the value in JavaScript, read it back and expect to get an object that is json-formattable to something
+	 * that matches the json formatting 
+	 * @param <TYPE>
+	 * @param value javascript-formatted variable value.
+	 * @param clazz which the given value should be json-parsable into.
+	 * @throws ScriptException
+	 */
+	protected static <TYPE> void variableTest(String value, Class<TYPE> clazz) throws ScriptException {
+		// Create an assignment statement using the given string value.
+		String varName = "m";
+		String script = "var " + varName + " = " + value; 
+		JScriptEngine engine = new JScriptEngine();
+		Map<String,Object> inputBindings = new HashMap<>();
+		Map<String,Object> outputBindings = engine.runScript(script, inputBindings, false);
+		
+		// Retreive the value of the assigned object back.
+		Assert.assertTrue(outputBindings != null);
+		Object assignedValue = outputBindings.get(varName);
+		Assert.assertTrue(assignedValue != null);
+
+		TYPE expectedValue = gson.fromJson(value, clazz);
+		Assert.assertTrue(expectedValue.equals(assignedValue));
+//		String emJson = gson.toJson(expectedValue);
+//		String jsObjJson = gson.toJson(assignedValue);
+//		Assert.assertTrue(emJson.equals(jsObjJson));
+
+		// This is not strictly necessary, but since we use JavaScript to create IClassifier instances, which
+		// must be serializable and which are sometimes configured (python) with the javascript values placed
+		// into them, we do this check also.
+		Assert.assertTrue(assignedValue instanceof Serializable);
+	}
+}


### PR DESCRIPTION
Changed JScriptEngine to use 'JavaScript' instead of 'nashorn' engine with new dependencies for graal.

This uncovered a bug in a test that was passing in string instead of a float value to the javascript to create the classifiers.

This allows us to run on Java 15 and later which no longer include Nashorn.