### PR TITLE
Fix bug in soundclip lengths not being the same when clipping and padding

### DIFF
--- a/aisp-core/aisp-core-main/src/main/java/org/eng/aisp/AbstractDataWindow.java
+++ b/aisp-core/aisp-core-main/src/main/java/org/eng/aisp/AbstractDataWindow.java
@@ -114,7 +114,8 @@ public abstract class AbstractDataWindow<WINDATA> extends InstanceIdentifiedObje
 			
 		this.startTimeMsec = startTimeMsec;
 		this.endTimeMsec = endTimeMsec;
-		this.samplesPerSecond = samplesPerSecond;
+//		this.samplesPerSecond = samplesPerSecond;
+		this.samplesPerSecond = (int)(samplesPerSecond + .5);
 //		if (context != null)
 //			this.context.putAll(context);
 		this.independentVector = independentData;
@@ -226,7 +227,8 @@ public abstract class AbstractDataWindow<WINDATA> extends InstanceIdentifiedObje
 			if (index > maxIndex)
 				index = maxIndex;
 		} else {				// If an upper bound of a window, then compute the index <= this time.
-			index = (int)(msecOffset * samplesPerMsec) ; 	// Index of 1st sample after requested offset.
+//			index = (int)(msecOffset * samplesPerMsec) ; 	// Index of 1st sample after requested offset.
+			index = (int)(msecOffset * samplesPerMsec + 0.5) ; 	// Index of 1st sample after requested offset.
 		}
 		return index;
 		

--- a/aisp-core/aisp-core-main/src/main/java/org/eng/aisp/tools/GetModifiedSoundOptions.java
+++ b/aisp-core/aisp-core-main/src/main/java/org/eng/aisp/tools/GetModifiedSoundOptions.java
@@ -166,12 +166,16 @@ public class GetModifiedSoundOptions extends GetSoundOptions {
 		
 		// Padding option
 		String padOption = cmdargs.getOption("pad", "no");
-		if (padOption.equals("zero"))
+		if (padOption.equals("zero")) {
 			padType = PadType.ZeroPad;
-		else if (padOption.equals("duplicate"))
+		} else if (padOption.equals("duplicate")) {
 			padType = PadType.DuplicatePad;
-		else
+		} else if (padOption.equals("no")) {
 			padType = PadType.NoPad;
+		} else {
+			System.err.println("Unrecognized pad type '" + padOption + "'");
+			return false;
+		}
 
 		boolean balancedLabels;
 		boolean useUpSampling; 
@@ -249,6 +253,13 @@ public class GetModifiedSoundOptions extends GetSoundOptions {
 				msg = "Sounds will be clipped every " + clipLenMsec + " msec into " + clipLenMsec + " msec clips (padding=" + padType.name() + ")";
 			System.out.println(msg);
 			sounds = new FixedDurationSoundRecordingShuffleIterable(sounds, clipLenMsec, clipShiftMsec, padType);
+//			int index=0;
+//			for (SoundRecording sr : sounds) {
+//				SoundClip clip = sr.getDataWindow();
+//				byte[] pcmData = clip.getPCMData();
+//				System.out.println("index=" + index + ", pcmData length = " + pcmData.length + ", tags: " + sr.getTags());
+//				index++;
+//			}
 //			System.out.println(TrainingSetInfo.getInfo(sounds).prettyFormat());
 //			if (repeatableShuffle && balancedLabels) {
 //				System.err.println("NOTE: repeatable shufflability (the default) while balancing labels and clipping\n"


### PR DESCRIPTION
Changes AbstractDataWindow to round sampling rates to integers, which they usually are anyway.  However, this takes a conservative approach and only rounds when the rate is already very near an integer value.